### PR TITLE
support multi definition of assemblies in assembly property

### DIFF
--- a/src/main/java/org/sonar/plugins/fxcop/FxCopConfiguration.java
+++ b/src/main/java/org/sonar/plugins/fxcop/FxCopConfiguration.java
@@ -84,17 +84,19 @@ public class FxCopConfiguration {
   }
 
   private void checkAssemblyProperty(Settings settings) {
-    String assemblyPath = settings.getString(assemblyPropertyKey);
+    String[] assembliesPaths = settings.getString(assemblyPropertyKey).split(",");
 
-    File assemblyFile = new File(assemblyPath);
-    Preconditions.checkArgument(
-      assemblyFile.isFile(),
-      "Cannot find the assembly \"" + assemblyFile.getAbsolutePath() + "\" provided by the property \"" + assemblyPropertyKey + "\".");
+    for(String assemblyPath : assembliesPaths) {
+      File assemblyFile = new File(assemblyPath);
+      Preconditions.checkArgument(
+        assemblyFile.isFile(),
+        "Cannot find the assembly \"" + assemblyFile.getAbsolutePath() + "\" provided by the property \"" + assemblyPropertyKey + "\".");
 
-    File pdbFile = new File(pdbPath(assemblyPath));
-    Preconditions.checkArgument(
-      pdbFile.isFile(),
-      "Cannot find the .pdb file \"" + pdbFile.getAbsolutePath() + "\" inferred from the property \"" + assemblyPropertyKey + "\".");
+      File pdbFile = new File(pdbPath(assemblyPath));
+      Preconditions.checkArgument(
+        pdbFile.isFile(),
+        "Cannot find the .pdb file \"" + pdbFile.getAbsolutePath() + "\" inferred from the property \"" + assemblyPropertyKey + "\".");
+    }
   }
 
   private static String pdbPath(String assemblyPath) {

--- a/src/main/java/org/sonar/plugins/fxcop/FxCopExecutor.java
+++ b/src/main/java/org/sonar/plugins/fxcop/FxCopExecutor.java
@@ -35,7 +35,6 @@ public class FxCopExecutor {
 
   public void execute(String executable, String assemblies, File rulesetFile, File reportFile, int timeout, boolean aspnet) {
     Command command = Command.create(getExecutable(executable))
-      .addArgument("/file:" + assemblies)
       .addArgument("/ruleset:=" + rulesetFile.getAbsolutePath())
       .addArgument("/out:" + reportFile.getAbsolutePath())
       .addArgument("/outxsl:none")
@@ -44,6 +43,10 @@ public class FxCopExecutor {
     if (aspnet) {
       command.addArgument("/aspnet");
     }
+    for (String assembly : assemblies.split(",")) {
+      command.addArgument("/file:" + assembly);
+    }
+    
 
     int exitCode = CommandExecutor.create().execute(
       command,

--- a/src/test/java/org/sonar/plugins/fxcop/FxCopConfigurationTest.java
+++ b/src/test/java/org/sonar/plugins/fxcop/FxCopConfigurationTest.java
@@ -64,6 +64,17 @@ public class FxCopConfigurationTest {
 
     new FxCopConfiguration("", "", "fooAssemblyKey", "fooFxCopCmdPathKey", "", "").checkProperties(settings);
   }
+  
+  @Test
+  public void check_properties_with_multiple_assemblies() {
+    Settings settings = mock(Settings.class);
+    when(settings.hasKey("fooAssemblyKey")).thenReturn(true);
+    when(settings.getString("fooAssemblyKey")).thenReturn(new File("src/test/resources/FxCopConfigurationTest/MyLibrary.dll").getAbsolutePath() + "," + new File("src/test/resources/FxCopConfigurationTest/MyLibrary.dll").getAbsolutePath());
+    when(settings.hasKey("fooFxCopCmdPathKey")).thenReturn(true);
+    when(settings.getString("fooFxCopCmdPathKey")).thenReturn(new File("src/test/resources/FxCopConfigurationTest/FxCopCmd.exe").getAbsolutePath());
+
+    new FxCopConfiguration("", "", "fooAssemblyKey", "fooFxCopCmdPathKey", "", "", "").checkProperties(settings);
+  }  
 
   @Test
   public void check_properties_without_assembly_extension() {


### PR DESCRIPTION
with this enhancement one can now have multi language without the need of using the bootstrapper or multi module. 

Fxcop runs once for all solution, for example if https://github.com/SonarCommunity/sonar-resharper/pull/1 is merged you can have:

sonar.visualstudio.enable=false
sonar.scm.enabled=true
sonar.scm.url=scm:git:http://stash/scm/ts/structures
sonar.cs.fxcop.fxCopCmdPath=c:/Tekla/BuildTools/FxCop/FxCopCmd.exe
sonar.resharper.inspectCodePath=c:/Tekla/BuildTools/resharpercli/inspectcode.exe
sonar.sourceEncoding=UTF-8
sonar.sources=.
sonar.visualstudio.outputPaths=../../BuildDrop/Work/bin
sonar.cs.opencover.reportsPaths=*.coverage.xml
sonar.stylecop.projectFilePath=./TeklaStructures.sln
sonar.resharper.solutionFile=TeklaStructures.sln
sonar.cs.fxcop.assembly=../../BuildDrop/Work/bin/Assembly.dll,../../BuildDrop/Work/bin/Assembly2.exe
sonar.cs.fxcop.directory=../../BuildDrop/Work/bin

And everything gets imported correctly into sonar without any additional configuration from the user side. This is much simpler than defining modules one by one.

Please consider this enhacement

