### PR TITLE
support fsharp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>220000</maxsize>
+                  <maxsize>320000</maxsize>
                   <minsize>200000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>

--- a/src/main/resources/org/sonar/plugins/fxcop/fs-rules.xml
+++ b/src/main/resources/org/sonar/plugins/fxcop/fs-rules.xml
@@ -1,0 +1,14285 @@
+<rules>
+
+  <rule key="CustomRuleTemplate">
+    <cardinality>MULTIPLE</cardinality>
+    <priority>MAJOR</priority>
+    <name><![CDATA[Template for custom FxCop rules]]></name>
+    <description>
+      <![CDATA[
+<p>
+Follow these steps to make your custom FxCop rules available in SonarQube:
+</p>
+
+<ol>
+  <li>Place your custom FxCop rules assemblies in the "Rules" subdirectory of your FxCop installation directory.</li>
+  <li>For each custom rule:</li>
+  <ol>
+    <li>Create a new rule in SonarQube by "copying" this rule template and specify the <code>CheckId</code> of your custom rule, a title, a description, and a default severity.</li>
+    <li>Enable the newly created rule in your quality profile</li>
+  </ol>
+  <li>Relaunch an analysis on your projects, et voilà, your custom rules are executed!</li>
+</ol>
+      ]]>
+    </description>
+    <param key="CheckId" />
+  </rule>
+
+  <rule key="DoNotDeclareStaticMembersOnGenericTypes">
+    <configKey>CA1000</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1000: Do not declare static members on generic types]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An externally visible generic type contains a <code>static</code> (<code>Shared</code> in Visual Basic) member.
+</p>
+<h2>Rule Description</h2>
+<p>
+            When a <code>static</code> member of a generic type is called, the type argument must be specified for the type. When a generic instance member that does not support inference is called, the type argument must be specified for the member. The syntax for specifying the type argument in these two cases is different and easily confused, as the following calls demonstrate:
+
+
+
+
+
+
+
+
+
+            <pre>
+// Static method in a generic type.
+GenericType&lt;int&gt;.StaticMethod();
+
+// Generic instance method that does not support inference.
+someObject.GenericMethod&lt;int&gt;();
+</pre>
+
+
+
+
+Generally, both of the prior declarations should be avoided so that the type argument does not have to be specified when the member is called. This results in a syntax for calling members in generics that is no different from the syntax for non-generics. For more information, see {rule:fxcop:GenericMethodsShouldProvideTypeParameter}.
+
+
+
+
+
+
+                How to Fix Violations
+
+
+
+
+
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule. Providing generics in a syntax that is easy to understand and use reduces the time that is required to learn and increases the adoption rate of new libraries.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:AvoidExcessiveParametersOnGenericTypes}<br/>
+
+
+
+
+                {rule:fxcop:CollectionsShouldImplementGenericInterface}<br/>
+
+
+
+
+                {rule:fxcop:DoNotExposeGenericLists}<br/>
+
+
+
+
+                {rule:fxcop:DoNotNestGenericTypesInMemberSignatures}<br/>
+
+
+
+
+                {rule:fxcop:GenericMethodsShouldProvideTypeParameter}<br/>
+
+
+
+
+                {rule:fxcop:UseGenericEventHandlerInstances}<br/>
+
+
+
+
+                {rule:fxcop:UseGenericsWhereAppropriate}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182139.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182139.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="TypesThatOwnDisposableFieldsShouldBeDisposable">
+    <configKey>CA1001</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1001: Types that own disposable fields should be disposable]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A class declares and implements an instance field that is a <code>System.IDisposable</code> type and the class does not implement <code>IDisposable</code>.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A class implements the <code>IDisposable</code> interface to dispose of unmanaged resources that it owns. An instance field that is an <code>IDisposable</code> type indicates that the field owns an unmanaged resource. A class that declares an <code>IDisposable</code> field indirectly owns an unmanaged resource and should implement the <code>IDisposable</code> interface. If the class does not directly own any unmanaged resources, it should not implement a finalizer.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, implement <code>IDisposable</code> and from the <code>IDisposable.Dispose</code> method call the <code>Dispose</code> method of the field.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:DisposableFieldsShouldBeDisposed}<br/>
+
+
+
+
+                {rule:fxcop:DisposableTypesShouldDeclareFinalizer}<br/>
+
+
+
+
+                {rule:fxcop:DisposeMethodsShouldCallBaseClassDispose}<br/>
+
+
+
+
+                {rule:fxcop:TypesThatOwnNativeResourcesShouldBeDisposable}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182172.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182172.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotExposeGenericLists">
+    <configKey>CA1002</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1002: Do not expose generic lists]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type contains an externally visible member that is a <code>System.Collections.Generic.List&lt;T&gt;</code> type, returns a <code>System.Collections.Generic.List&lt;T&gt;</code> type, or whose signature includes a <code>System.Collections.Generic.List&lt;T&gt;</code> parameter.
+</p>
+<h2>Rule Description</h2>
+<p>
+
+
+                <code>System.Collections.Generic.List&lt;T&gt;</code>
+               is a generic collection that is designed for performance and not inheritance. <code>System.Collections.Generic.List&lt;T&gt;</code> does not contain virtual members that make it easier to change the behavior of an inherited class. The following generic collections are designed for inheritance and should be exposed instead of <code>System.Collections.Generic.List&lt;T&gt;</code>.
+            <ul>
+              <li>
+
+
+                    System.Collections.ObjectModel.Collection&lt;T&gt;
+
+
+              </li>
+              <li>
+
+
+                    System.Collections.ObjectModel.ReadOnlyCollection&lt;T&gt;
+
+
+              </li>
+              <li>
+
+
+                    System.Collections.ObjectModel.KeyedCollection&lt;TKey, TItem&gt;
+
+
+              </li>
+            </ul>
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the <code>System.Collections.Generic.List&lt;T&gt;</code> type to one of the generic collections that is designed for inheritance.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule unless the assembly that raises this warning is not meant to be a reusable library. For example, it would be safe to suppress this warning in a performance tuned application where a performance benefit was gained from the use of generic lists.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:AvoidExcessiveParametersOnGenericTypes}<br/>
+
+
+
+
+                {rule:fxcop:CollectionsShouldImplementGenericInterface}<br/>
+
+
+
+
+                {rule:fxcop:DoNotDeclareStaticMembersOnGenericTypes}<br/>
+
+
+
+
+                {rule:fxcop:DoNotNestGenericTypesInMemberSignatures}<br/>
+
+
+
+
+                {rule:fxcop:GenericMethodsShouldProvideTypeParameter}<br/>
+
+
+
+
+                {rule:fxcop:UseGenericEventHandlerInstances}<br/>
+
+
+
+
+                {rule:fxcop:UseGenericsWhereAppropriate}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182142.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182142.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="UseGenericEventHandlerInstances">
+    <configKey>CA1003</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1003: Use generic event handler instances]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type contains a delegate that returns void, whose signature contains two parameters (the first an object and the second a type that is assignable to EventArgs), and the containing assembly targets .NET Framework 2.0.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Before .NET Framework 2.0, in order to pass custom information to the event handler, a new delegate had to be declared that specified a class that was derived from the <code>System.EventArgs</code> class. This is no longer true in .NET Framework 2.0, which introduced the System.EventHandler&lt;TEventArgs&gt; delegate. This generic delegate allows any class that is derived from <code>EventArgs</code> to be used together with the event handler.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, remove the delegate and replace its use by using the System.EventHandler&lt;TEventArgs&gt; delegate. If the delegate is autogenerated by the Visual Basic compiler, change the syntax of the event declaration to use the System.EventHandler&lt;TEventArgs&gt; delegate.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:AvoidExcessiveParametersOnGenericTypes}<br/>
+
+
+
+
+                {rule:fxcop:CollectionsShouldImplementGenericInterface}<br/>
+
+
+
+
+                {rule:fxcop:DoNotDeclareStaticMembersOnGenericTypes}<br/>
+
+
+
+
+                {rule:fxcop:DoNotExposeGenericLists}<br/>
+
+
+
+
+                {rule:fxcop:DoNotNestGenericTypesInMemberSignatures}<br/>
+
+
+
+
+                {rule:fxcop:GenericMethodsShouldProvideTypeParameter}<br/>
+
+
+
+
+                {rule:fxcop:UseGenericsWhereAppropriate}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182178.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182178.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="GenericMethodsShouldProvideTypeParameter">
+    <configKey>CA1004</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1004: Generic methods should provide type parameter]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The parameter signature of an externally visible generic method does not contain types that correspond to all the type parameters of the method.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Inference is how the type argument of a generic method is determined by the type of argument that is passed to the method, instead of by the explicit specification of the type argument. To enable inference, the parameter signature of a generic method must include a parameter that is of the same type as the type parameter for the method. In this case, the type argument does not have to be specified. When you use inference for all type parameters, the syntax for calling generic and nongeneric instance methods is identical. This simplifies the usability of generic methods.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the design so that the parameter signature contains the same type for each type parameter of the method.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule. Providing generics in a syntax that is easy to understand and use reduces the time that is required to learn and increases the adoption rate of new libraries.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:AvoidExcessiveParametersOnGenericTypes}<br/>
+
+
+
+
+                {rule:fxcop:CollectionsShouldImplementGenericInterface}<br/>
+
+
+
+
+                {rule:fxcop:DoNotDeclareStaticMembersOnGenericTypes}<br/>
+
+
+
+
+                {rule:fxcop:DoNotExposeGenericLists}<br/>
+
+
+
+
+                {rule:fxcop:DoNotNestGenericTypesInMemberSignatures}<br/>
+
+
+
+
+                {rule:fxcop:UseGenericEventHandlerInstances}<br/>
+
+
+
+
+                {rule:fxcop:UseGenericsWhereAppropriate}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182150.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182150.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AvoidExcessiveParametersOnGenericTypes">
+    <configKey>CA1005</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1005: Avoid excessive parameters on generic types]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An externally visible generic type has more than two type parameters.
+</p>
+<h2>Rule Description</h2>
+<p>
+            The more type parameters a generic type contains, the more difficult it is to know and remember what each type parameter represents. It is usually obvious with one type parameter, as in List&lt;T&gt;, and in certain cases with two type parameters, as in Dictionary&lt;TKey, TValue&gt;. If more than two type parameters exist, the difficulty becomes too great for most users (for example, TooManyTypeParameters&lt;T, K, V&gt; in C# or TooManyTypeParameters(Of T, K, V) in Visual Basic).
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the design to use no more than two type parameters.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule unless the design absolutely requires more than two type parameters. Providing generics in a syntax that is easy to understand and use reduces the time that is required to learn and increases the adoption rate of new libraries.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:CollectionsShouldImplementGenericInterface}<br/>
+
+
+
+
+                {rule:fxcop:DoNotDeclareStaticMembersOnGenericTypes}<br/>
+
+
+
+
+                {rule:fxcop:DoNotExposeGenericLists}<br/>
+
+
+
+
+                {rule:fxcop:DoNotNestGenericTypesInMemberSignatures}<br/>
+
+
+
+
+                {rule:fxcop:GenericMethodsShouldProvideTypeParameter}<br/>
+
+
+
+
+                {rule:fxcop:UseGenericEventHandlerInstances}<br/>
+
+
+
+
+                {rule:fxcop:UseGenericsWhereAppropriate}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182129.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182129.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotNestGenericTypesInMemberSignatures">
+    <configKey>CA1006</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1006: Do not nest generic types in member signatures]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An externally visible member has a signature that contains a nested type argument.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A nested type argument is a type argument that is also a generic type. To call a member whose signature contains a nested type argument, the user must instantiate one generic type and pass this type to the constructor of a second generic type. The required procedure and syntax are complex and should be avoided.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the design to remove the nested type argument.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule. Providing generics in a syntax that is easy to understand and use reduces the time that is required to learn and increases the adoption rate of new libraries.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:AvoidExcessiveParametersOnGenericTypes}<br/>
+
+
+
+
+                {rule:fxcop:CollectionsShouldImplementGenericInterface}<br/>
+
+
+
+
+                {rule:fxcop:DoNotDeclareStaticMembersOnGenericTypes}<br/>
+
+
+
+
+                {rule:fxcop:DoNotExposeGenericLists}<br/>
+
+
+
+
+                {rule:fxcop:GenericMethodsShouldProvideTypeParameter}<br/>
+
+
+
+
+                {rule:fxcop:UseGenericEventHandlerInstances}<br/>
+
+
+
+
+                {rule:fxcop:UseGenericsWhereAppropriate}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182144.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182144.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="UseGenericsWhereAppropriate">
+    <configKey>CA1007</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1007: Use generics where appropriate]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An externally visible method contains a reference parameter of type <code>System.Object</code>, and the containing assembly targets .NET Framework 2.0.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A reference parameter is a parameter that is modified by using the <code>ref</code> (<code>ByRef</code> in Visual Basic) keyword. The argument type that is supplied for a reference parameter must exactly match the reference parameter type. To use a type that is derived from the reference parameter type, the type must first be cast and assigned to a variable of the reference parameter type. Use of a generic method allows all types, subject to constraints, to be passed to the method without first casting the type to the reference parameter type.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, make the method generic and replace the <code>Object</code> parameter by using a type parameter.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:AvoidExcessiveParametersOnGenericTypes}<br/>
+
+
+
+
+                {rule:fxcop:CollectionsShouldImplementGenericInterface}<br/>
+
+
+
+
+                {rule:fxcop:DoNotDeclareStaticMembersOnGenericTypes}<br/>
+
+
+
+
+                {rule:fxcop:DoNotExposeGenericLists}<br/>
+
+
+
+
+                {rule:fxcop:DoNotNestGenericTypesInMemberSignatures}<br/>
+
+
+
+
+                {rule:fxcop:GenericMethodsShouldProvideTypeParameter}<br/>
+
+
+
+
+                {rule:fxcop:UseGenericEventHandlerInstances}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182179.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182179.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="EnumsShouldHaveZeroValue">
+    <configKey>CA1008</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1008: Enums should have zero value]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An enumeration without an applied <code>System.FlagsAttribute</code> does not define a member that has a value of zero; or an enumeration that has an applied <code>FlagsAttribute</code> defines a member that has a value of zero but its name is not 'None', or the enumeration defines multiple zero-valued members.
+</p>
+<h2>Rule Description</h2>
+<p>
+            The default value of an uninitialized enumeration, just like other value types, is zero. A non-flags−attributed enumeration should define a member that has the value of zero so that the default value is a valid value of the enumeration. If appropriate, name the member 'None'. Otherwise, assign zero to the most frequently used member. Note that, by default, if the value of the first enumeration member is not set in the declaration, its value is zero.
+            If an enumeration that has the <code>FlagsAttribute</code> applied defines a zero-valued member, its name should be 'None' to indicate that no values have been set in the enumeration. Using a zero-valued member for any other purpose is contrary to the use of the <code>FlagsAttribute</code> in that the AND and OR bitwise operators are useless with the member. This implies that only one member should be assigned the value zero. Note that if multiple members that have the value zero occur in a flags-attributed enumeration, Enum.ToString() returns incorrect results for members that are not zero.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule for non-flags−attributed enumerations, define a member that has the value of zero; this is a non-breaking change. For flags-attributed enumerations that define a zero-valued member, name this member 'None' and delete any other members that have a value of zero; this is a breaking change.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule except for flags-attributed enumerations that have previously shipped.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:DoNotMarkEnumsWithFlags}<br/>
+
+
+
+
+                {rule:fxcop:DoNotNameEnumValuesReserved}<br/>
+
+
+
+
+                {rule:fxcop:DoNotPrefixEnumValuesWithTypeName}<br/>
+
+
+
+
+                {rule:fxcop:EnumStorageShouldBeInt32}<br/>
+
+
+
+
+                {rule:fxcop:MarkEnumsWithFlags}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182149.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182149.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DeclareEventHandlersCorrectly">
+    <configKey>CA1009</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1009: Declare event handlers correctly]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Event handler methods take two parameters. The first is of type <code>System.Object</code> and is named 'sender'. This is the object that raised the event. The second parameter is of type <code>System.EventArgs</code> and is named 'e'. This is the data that is associated with the event. For example, if the event is raised whenever a file is opened, the event data typically contains the name of the file.
+            Event handler methods should not return a value. In the C# programming language, this is indicated by the return type <code>void</code>. An event handler can invoke multiple methods in multiple objects. If the methods were allowed to return a value, multiple return values would occur for each event, and only the value of the last method that was invoked would be available.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, correct the signature, return type, or parameter names of the delegate. For details, see the following example.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:ReviewVisibleEventHandlers}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182133.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182133.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="CollectionsShouldImplementGenericInterface">
+    <configKey>CA1010</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1010: Collections should implement generic interface]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An externally visible type implements the <code>System.Collections.IEnumerable</code> interface but does not implement the <code>System.Collections.Generic.IEnumerable&lt;T&gt;</code> interface, and the containing assembly targets .NET Framework 2.0. This rule ignores types that implement <code>System.Collections.IDictionary</code>.
+</p>
+<h2>Rule Description</h2>
+<p>
+            To broaden the usability of a collection, implement one of the generic collection interfaces. Then the collection can be used to populate generic collection types such as the following:
+            <ul>
+              <li>
+
+
+                    <code>System.Collections.Generic.List&lt;T&gt;</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.Collections.Generic.Queue&lt;T&gt;</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.Collections.Generic.Stack&lt;T&gt;</code>
+
+
+              </li>
+            </ul>
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, implement one of the following generic collection interfaces:
+            <ul>
+              <li>
+
+
+                    <code>System.Collections.Generic.IEnumerable&lt;T&gt;</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.Collections.Generic.ICollection&lt;T&gt;</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.Collections.Generic.IList&lt;T&gt;</code>
+
+
+              </li>
+            </ul>
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule; however, the collection will have a more limited use.
+</p>
+<h2>Example Violation</h2>
+
+<h3>Description</h3>
+<p>
+                The following example shows a class (reference type) that derives from the non-generic CollectionBase class, which violates this rule.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+using System.Collections;
+
+namespace Samples
+{
+    public class Book
+    {
+        public Book()
+        {
+        }
+    }
+
+    public class BookCollection : CollectionBase
+    {
+        public BookCollection()
+        {
+        }
+
+        public void Add(Book value)
+        {
+            InnerList.Add(value);
+        }
+
+        public void Remove(Book value)
+        {
+            InnerList.Remove(value);
+        }
+
+        public void Insert(int index, Book value)
+        {
+            InnerList.Insert(index, value);
+        }
+
+        public Book this[int index]
+        {
+            get { return (Book)InnerList[index]; }
+            set { InnerList[index] = value; }
+        }
+
+        public bool Contains(Book value)
+        {
+            return InnerList.Contains(value);
+        }
+
+        public int IndexOf(Book value)
+        {
+            return InnerList.IndexOf(value);
+        }
+
+        public void CopyTo(Book[] array, int arrayIndex)
+        {
+            InnerList.CopyTo(array, arrayIndex);
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h3>Comments</h3>
+<p>
+                To fix a violation of this violation, you should either implement the generic interfaces or change the base class to a type that already implements both the generic and non-generic interfaces, such as the Collection&lt;T&gt; class.
+</p>
+<h2>Fix by Base Class Change</h2>
+
+<h3>Description</h3>
+<p>
+                The following example fixes the violation by changing the base class of the collection from the non-generic CollectionBase class to the generic Collection&lt;T&gt; (Collection(Of T) in Visual Basic) class.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+using System.Collections.ObjectModel;
+
+namespace Samples
+{
+    public class Book
+    {
+        public Book()
+        {
+        }
+    }
+
+    public class BookCollection : Collection&lt;Book&gt;
+    {
+        public BookCollection()
+        {
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h3>Comments</h3>
+<p>
+                Changing the base class of an already released class is considered a breaking change to existing consumers.
+</p>
+<h2>Fix by Interface Implementation</h2>
+
+<h3>Description</h3>
+<p>
+                The following example fixes the violation by implementing these generic interfaces: IEnumerable&lt;T&gt;, ICollection&lt;T&gt;, and IList&lt;T&gt; (IEnumerable(Of T), ICollection(Of T), and IList(Of T) in Visual Basic).
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Samples
+{
+    public class Book
+    {
+        public Book()
+        {
+        }
+    }
+
+    public class BookCollection : CollectionBase, IList&lt;Book&gt;
+    {
+        public BookCollection()
+        {
+        }
+
+        int IList&lt;Book&gt;.IndexOf(Book item)
+        {
+            return this.List.IndexOf(item);
+        }
+
+        void IList&lt;Book&gt;.Insert(int location, Book item)
+        {
+        }
+
+        Book IList&lt;Book&gt;.this[int index]
+        {
+            get { return (Book) this.List[index]; }
+            set { }
+        }
+
+        void ICollection&lt;Book&gt;.Add(Book item)
+        {
+        }
+
+        bool ICollection&lt;Book&gt;.Contains(Book item)
+        {
+            return true;
+        }
+
+        void ICollection&lt;Book&gt;.CopyTo(Book[] array, int arrayIndex)
+        {
+        }
+
+        bool ICollection&lt;Book&gt;.IsReadOnly
+        {
+            get { return false; }
+        }
+
+        bool ICollection&lt;Book&gt;.Remove(Book item)
+        {
+            if (InnerList.Contains(item))
+            {
+                InnerList.Remove(item);
+                return true;
+            }
+            return false;
+        }
+
+        IEnumerator&lt;Book&gt; IEnumerable&lt;Book&gt;.GetEnumerator()
+        {
+            return new BookCollectionEnumerator(InnerList.GetEnumerator());
+        }
+
+        private class BookCollectionEnumerator : IEnumerator&lt;Book&gt;
+        {
+            private IEnumerator _Enumerator;
+
+            public BookCollectionEnumerator(IEnumerator enumerator)
+            {
+                _Enumerator = enumerator;
+            }
+
+            public Book Current
+            {
+                get { return (Book)_Enumerator.Current; }
+            }
+
+            object IEnumerator.Current
+            {
+                get { return _Enumerator.Current; }
+            }
+
+            public bool MoveNext()
+            {
+                return _Enumerator.MoveNext();
+            }
+
+            public void Reset()
+            {
+                _Enumerator.Reset();
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:AvoidExcessiveParametersOnGenericTypes}<br/>
+
+
+
+
+                {rule:fxcop:DoNotDeclareStaticMembersOnGenericTypes}<br/>
+
+
+
+
+                {rule:fxcop:DoNotExposeGenericLists}<br/>
+
+
+
+
+                {rule:fxcop:DoNotNestGenericTypesInMemberSignatures}<br/>
+
+
+
+
+                {rule:fxcop:GenericMethodsShouldProvideTypeParameter}<br/>
+
+
+
+
+                {rule:fxcop:UseGenericEventHandlerInstances}<br/>
+
+
+
+
+                {rule:fxcop:UseGenericsWhereAppropriate}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182132.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182132.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ConsiderPassingBaseTypesAsParameters">
+    <configKey>CA1011</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1011: Consider passing base types as parameters]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method declaration includes a formal parameter that is a derived type, and the method calls only members of the base type of the parameter.
+</p>
+<h2>Rule Description</h2>
+<p>
+            When a base type is specified as a parameter in a method declaration, any type that is derived from the base type can be passed as the corresponding argument to the method. When the argument is used inside the method body, the specific method that is executed depends on the type of the argument. If the additional functionality that is provided by the derived type is not required, use of the base type allows wider use of the method.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the type of the parameter to its base type.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule
+            <ul>
+              <li>
+                if the method requires the specific functionality that is provided by the derived type
+                - or -
+              </li>
+              <li>
+                to enforce that only the derived type, or a more derived type, is passed to the method.
+              </li>
+            </ul>
+            In these cases, the code will be more robust because of the strong type checking that is provided by the compiler and runtime.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:MembersShouldNotExposeCertainConcreteTypes}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/3hk32yyz.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/3hk32yyz.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AbstractTypesShouldNotHaveConstructors">
+    <configKey>CA1012</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1012: Abstract types should not have constructors]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public type is abstract and has a public constructor.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Constructors on abstract types can be called only by derived types. Because public constructors create instances of a type, and you cannot create instances of an abstract type, an abstract type that has a public constructor is incorrectly designed.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, either make the constructor protected or do not declare the type as abstract.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule. The abstract type has a public constructor.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182126.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182126.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="OverloadOperatorEqualsOnOverloadingAddAndSubtract">
+    <configKey>CA1013</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1013: Overload operator equals on overloading add and subtract]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected type implements the addition or subtraction operators without implementing the equality operator.
+</p>
+<h2>Rule Description</h2>
+<p>
+            When instances of a type can be combined by using operations such as addition and subtraction, you should almost always define equality to return <code>true</code> for any two instances that have the same constituent values.
+            You cannot use the default equality operator in an overloaded implementation of the equality operator. Doing so will cause a stack overflow. To implement the equality operator, use the Object.Equals method in your implementation. See the following example.
+
+
+
+
+
+
+
+
+
+            <pre>
+if (Object.ReferenceEquals(left, null))
+    return Object.ReferenceEquals(right, null);
+return left.Equals(right);
+</pre>
+
+
+
+
+
+
+
+
+
+
+
+                How to Fix Violations
+
+
+
+
+
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule when the default implementation of the equality operator provides the correct behavior for the type.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182164.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182164.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="MarkAssembliesWithClsCompliant">
+    <configKey>CA1014</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1014: Mark assemblies with CLSCompliantAttribute]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An assembly does not have the <code>System.CLSCompliantAttribute</code> attribute applied to it.
+</p>
+<h2>Rule Description</h2>
+<p>
+            The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance with <code>CLSCompliantAttribute</code>. If the attribute is not present on an assembly, the assembly is not compliant.
+            It is possible for a CLS-compliant assembly to contain types or type members that are not compliant.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, add the attribute to the assembly. Instead of marking the whole assembly as noncompliant, you should determine which type or type members are not compliant and mark these elements as such. If possible, you should provide a CLS-compliant alternative for noncompliant members so that the widest possible audience can access all the functionality of your assembly.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule. If you do not want the assembly to be compliant, apply the attribute and set its value to <code>false</code>.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182156.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182156.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="MarkAssembliesWithAssemblyVersion">
+    <configKey>CA1016</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1016: Mark assemblies with AssemblyVersionAttribute]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The assembly does not have a version number.
+</p>
+<h2>Rule Description</h2>
+<p>
+            The identity of an assembly is composed of the following information:
+            <ul>
+              <li>
+                Assembly name
+              </li>
+              <li>
+                Version number
+              </li>
+              <li>
+                Culture
+              </li>
+              <li>
+                Public key (for strongly named assemblies).
+              </li>
+            </ul>
+            The .NET Framework uses the version number to uniquely identify an assembly, and to bind to types in strongly named assemblies. The version number is used together with version and publisher policy. By default, applications run only with the assembly version with which they were built.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, add a version number to the assembly by using the <code>System.Reflection.AssemblyVersionAttribute</code> attribute. See the following example.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule for assemblies that are used by third parties, or in a production environment.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182155.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182155.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="MarkAssembliesWithComVisible">
+    <configKey>CA1017</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1017: Mark assemblies with ComVisibleAttribute]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An assembly does not have the <code>System.Runtime.InteropServices.ComVisibleAttribute</code> attribute applied to it.
+</p>
+<h2>Rule Description</h2>
+<p>
+            The <code>ComVisibleAttribute</code> attribute determines how COM clients access managed code. Good design dictates that assemblies explicitly indicate COM visibility. COM visibility can be set for a whole assembly and then overridden for individual types and type members. If the attribute is not present, the contents of the assembly are visible to COM clients.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, add the attribute to the assembly. If you do not want the assembly to be visible to COM clients, apply the attribute and set its value to <code>false</code>.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule. If you want the assembly to be visible, apply the attribute and set its value to <code>true</code>.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182157.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182157.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="MarkAttributesWithAttributeUsage">
+    <configKey>CA1018</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1018: Mark attributes with AttributeUsageAttribute]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The <code>System.AttributeUsageAttribute</code> attribute is not present on the custom attribute.
+</p>
+<h2>Rule Description</h2>
+<p>
+            When you define a custom attribute, mark it by using <code>AttributeUsageAttribute</code> to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code. For example, you might define an attribute that identifies the person who is responsible for maintaining and enhancing each type in a library, and that responsibility is always assigned at the type level. In this case, compilers should enable the attribute on classes, enumerations, and interfaces, but should not enable it on methods, events, or properties. Organizational policies and procedures would dictate whether the attribute should be enabled on assemblies.
+            The <code>System.AttributeTargets</code> enumeration defines the targets that you can specify for a custom attribute. If you omit <code>AttributeUsageAttribute</code>, your custom attribute will be valid for all targets, as defined by the <code>All</code> value of <code>AttributeTargets</code> enumeration.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, specify targets for the attribute by using <code>AttributeUsageAttribute</code>. See the following example.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            You should fix a violation of this rule instead of excluding the message. Even if the attribute inherits <code>AttributeUsageAttribute</code>, the attribute should be present to simplify code maintenance.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:DefineAccessorsForAttributeArguments}<br/>
+
+
+
+
+                {rule:fxcop:AvoidUnsealedAttributes}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182158.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182158.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DefineAccessorsForAttributeArguments">
+    <configKey>CA1019</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1019: Define accessors for attribute arguments]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            In its constructor, an attribute defines arguments that do not have corresponding properties.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Attributes can define mandatory arguments that must be specified when you apply the attribute to a target. These are also known as positional arguments because they are supplied to attribute constructors as positional parameters. For every mandatory argument, the attribute should also provide a corresponding read-only property so that the value of the argument can be retrieved at execution time. This rule checks that for each constructor parameter, you have defined the corresponding property.
+            Attributes can also define optional arguments, which are also known as named arguments. These arguments are supplied to attribute constructors by name and should have a corresponding read/write property.
+            For mandatory and optional arguments, the corresponding properties and constructor parameters should use the same name but different casing. Properties use Pascal casing, and parameters use camel casing.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, add a read-only property for each constructor parameter that does not have one.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Suppress a warning from this rule if you do not want the value of the mandatory argument to be retrievable.
+</p>
+<h2>Custom Attributes Example</h2>
+
+<h3>Description</h3>
+<p>
+                The following example shows two attributes that define a mandatory (positional) parameter. The first implementation of the attribute is incorrectly defined. The second implementation is correct.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+
+namespace DesignLibrary
+{
+// Violates rule: DefineAccessorsForAttributeArguments.
+
+   [AttributeUsage(AttributeTargets.All)]
+   public sealed class BadCustomAttribute :Attribute
+   {
+      string data;
+
+      // Missing the property that corresponds to  
+      // the someStringData parameter. 
+
+      public BadCustomAttribute(string someStringData)
+      {
+         data = someStringData;
+      }
+   }
+
+// Satisfies rule: Attributes should have accessors for all arguments.
+
+   [AttributeUsage(AttributeTargets.All)]
+   public sealed class GoodCustomAttribute :Attribute
+   {
+      string data;
+
+      public GoodCustomAttribute(string someStringData)
+      {
+         data = someStringData;
+      }
+      //The constructor parameter and property 
+      //name are the same except for case. 
+
+      public string SomeStringData
+      {
+         get
+         {
+            return data;
+         }
+      }
+   }
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>Positional and Named Arguments</h2>
+
+<h3>Description</h3>
+<p>
+                Positional and named arguments make to clear to consumers of your library which arguments are mandatory for the attribute and which arguments are optional.
+                The following example shows an implementation of an attribute that has both positional and named arguments.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+
+namespace DesignLibrary
+{
+    [AttributeUsage(AttributeTargets.All)]
+    public sealed class GoodCustomAttribute : Attribute
+    {
+        string mandatory;
+        string optional;
+
+        public GoodCustomAttribute(string mandatoryData)
+        {
+            mandatory = mandatoryData;
+        }
+
+        public string MandatoryData
+        {
+            get { return mandatory; }
+        }
+
+        public string OptionalData
+        {
+            get { return optional; }
+            set { optional = value; }
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h3>Comments</h3>
+<p>
+                The following example shows how to apply the custom attribute to two properties.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+[GoodCustomAttribute("ThisIsSomeMandatoryData", OptionalData = "ThisIsSomeOptionalData")]
+public string MyProperty
+{
+    get { return myProperty; }
+    set { myProperty = value; }
+}
+
+[GoodCustomAttribute("ThisIsSomeMoreMandatoryData")]
+public string MyOtherProperty
+{
+    get { return myOtherProperty; }
+    set { myOtherProperty = value; }
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:AvoidUnsealedAttributes}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182136.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182136.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AvoidNamespacesWithFewTypes">
+    <configKey>CA1020</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1020: Avoid namespaces with few types]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A namespace other than the global namespace contains fewer than five types.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Make sure that each of your namespaces has a logical organization, and that a valid reason exists to put types in a sparsely populated namespace. Namespaces should contain types that are used together in most scenarios. When their applications are mutually exclusive, types should be located in separate namespaces. For example, the <code>System.Web.UI</code> namespace contains types that are used in Web applications, and the <code>System.Windows.Forms</code> namespace contains types that are used in Windows-based applications. Even though both namespaces have types that control aspects of the user interface, these types are not designed for use in the same application. Therefore, they are located in separate namespaces. Careful namespace organization can also be helpful because it increases the discoverability of a feature. By examining the namespace hierarchy, library consumers should be able to locate the types that implement a feature.
+
+
+
+
+
+                    Note
+
+
+
+
+                    Design-time types and permissions should not be merged into other namespaces to comply with this guideline. These types belong in their own namespaces below your main namespace, and the namespaces should end in <code>.Design</code> and <code>.Permissions</code>, respectively.
+
+
+
+
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, try to combine namespaces that contain just a few types into a single namespace.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule when the namespace does not contain types that are used with the types in your other namespaces.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182130.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182130.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AvoidOutParameters">
+    <configKey>CA1021</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1021: Avoid out parameters]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected method in a public type has an <code>out</code> parameter.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Passing types by reference (using <code>out</code> or <code>ref</code>) requires experience with pointers, understanding how value types and reference types differ, and handling methods with multiple return values. Also, the difference between <code>out</code> and <code>ref</code> parameters is not widely understood.
+            When a reference type is passed "by reference," the method intends to use the parameter to return a different instance of the object. Passing a reference type by reference is also known as using a double pointer, pointer to a pointer, or double indirection. By using the default calling convention, which is pass "by value," a parameter that takes a reference type already receives a pointer to the object. The pointer, not the object to which it points, is passed by value. Pass by value means that the method cannot change the pointer to have it point to a new instance of the reference type. However, it can change the contents of the object to which it points. For most applications this is sufficient and yields the desired behavior.
+            If a method must return a different instance, use the return value of the method to accomplish this. See the <code>System.String</code> class for a variety of methods that operate on strings and return a new instance of a string. When this model is used, the caller must decide whether the original object is preserved.
+            Although return values are commonplace and heavily used, the correct application of <code>out</code> and <code>ref</code> parameters requires intermediate design and coding skills. Library architects who design for a general audience should not expect users to master working with <code>out</code> or <code>ref</code> parameters.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule that is caused by a value type, have the method return the object as its return value. If the method must return multiple values, redesign it to return a single instance of an object that holds the values.
+            To fix a violation of this rule that is caused by a reference type, make sure that the desired behavior is to return a new instance of the reference. If it is, the method should use its return value to do this.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule. However, this design could cause usability issues.
+</p>
+<h2>Example</h2>
+
+<h3>Description</h3>
+<p>
+                Methods that implement the Try&lt;Something&gt; pattern, such as Int32.TryParse, do not raise this violation. The following example shows a structure (value type) that implements the Int32.TryParse method.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+
+namespace Samples
+{
+    public struct Point
+    {
+        private readonly int _X;
+        private readonly int _Y;
+
+        public Point(int axisX, int axisY)
+        {
+            _X = axisX;
+            _Y = axisY;
+        }
+
+        public int X
+        {
+            get { return _X; }
+        }
+
+        public int Y
+        {
+            get { return _Y; }
+        }
+
+        public override int GetHashCode()
+        {
+            return _X ^ _Y;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is Point))
+                return false;
+
+            return Equals((Point)obj);
+        }
+
+        public bool Equals(Point other)
+        {
+            if (_X != other._X)
+                return false;
+
+            return _Y == other._Y;
+        }
+
+        public static bool operator ==(Point point1, Point point2)
+        {
+            return point1.Equals(point2);
+        }
+
+        public static bool operator !=(Point point1, Point point2)
+        {
+            return !point1.Equals(point2);
+        }
+
+        // Does not violate this rule 
+        public static bool TryParse(string value, out Point result)
+        {
+            // TryParse Implementation
+            result = new Point(0,0);
+            return false;
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:DoNotPassTypesByReference}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182131.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182131.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="IndexersShouldNotBeMultidimensional">
+    <configKey>CA1023</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1023: Indexers should not be multidimensional]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected type contains a public or protected indexer that uses more than one index.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Indexers, that is, indexed properties, should use a single index. Multi-dimensional indexers can significantly reduce the usability of the library. If the design requires multiple indexes, reconsider whether the type represents a logical data store. If not, use a method.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the design to use a lone integer or string index, or use a method instead of the indexer.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Suppress a warning from this rule only after carefully considering the need for the nonstandard indexer.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:UseIntegralOrStringArgumentForIndexers}<br/>
+
+
+
+
+                {rule:fxcop:UsePropertiesWhereAppropriate}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182152.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182152.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="UsePropertiesWhereAppropriate">
+    <configKey>CA1024</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1024: Use properties where appropriate]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected method has a name that starts with Get, takes no parameters, and returns a value that is not an array.
+</p>
+<h2>Rule Description</h2>
+<p>
+            In most cases, properties represent data and methods perform actions. Properties are accessed like fields, which makes them easier to use. A method is a good candidate to become a property if one of these conditions is present:
+            <ul>
+              <li>
+                Takes no arguments and returns the state information of an object.
+              </li>
+              <li>
+                Accepts a single argument to set some part of the state of an object.
+              </li>
+            </ul>
+            Properties should behave as if they are fields; if the method cannot, it should not be changed to a property. Methods are better than properties in the following situations:
+            <ul>
+              <li>
+                The method performs a time-consuming operation. The method is perceivably slower than the time that is required to set or get the value of a field.
+              </li>
+              <li>
+                The method performs a conversion. Accessing a field does not return a converted version of the data that it stores.
+              </li>
+              <li>
+                The Get method has an observable side effect. Retrieving the value of a field does not produce any side effects.
+              </li>
+              <li>
+                The order of execution is important. Setting the value of a field does not rely on the occurrence of other operations.
+              </li>
+              <li>
+                Calling the method two times in succession creates different results.
+              </li>
+              <li>
+                The method is static but returns an object that can be changed by the caller. Retrieving the value of a field does not allow the caller to change the data that is stored by the field.
+              </li>
+              <li>
+                The method returns an array.
+              </li>
+            </ul>
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the method to a property.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Suppress a warning from this rule if the method meets at least one of the previously listed criteria.
+</p>
+<h2>Controlling Property Expansion in the Debugger</h2>
+<p>
+            One reason programmers avoid using a property is because they do not want the debugger to auto-expand it. For example, the property might involve allocating a large object or calling a P/Invoke, but it might not actually have any observable side effects.
+            You can prevent the debugger from auto-expanding properties by applying <code>System.Diagnostics.DebuggerBrowsableAttribute</code>. The following example shows this attribute being applied to an instance property.
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.Samples
+{
+    public class TestClass
+    {
+        // [...]
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public LargeObject LargeObject
+        {
+            get
+            {
+                // Allocate large object
+                // [...]
+
+        }
+    }
+}
+</pre>
+
+
+
+
+
+
+
+
+
+
+
+                Example
+
+
+
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182181.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182181.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ReplaceRepetitiveArgumentsWithParamsArray">
+    <configKey>CA1025</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1025: Replace repetitive arguments with params array]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected method in a public type has more than three parameters, and its last three parameters are the same type.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Use a parameter array instead of repeated arguments when the exact number of arguments is unknown and the variable arguments are the same type, or can be passed as the same type. For example, the <code>WriteLine</code> method provides a general-purpose overload that uses a parameter array to accept any number of <code>Object</code> arguments.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, replace the repeated arguments with a parameter array.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is always safe to suppress a warning from this rule; however, this design might cause usability issues.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182167.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182167.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DefaultParametersShouldNotBeUsed">
+    <configKey>CA1026</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1026: Default parameters should not be used]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An externally visible type contains an externally visible method that uses a default parameter.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Methods that use default parameters are allowed under the Common Language Specification (CLS); however, the CLS allows compilers to ignore the values that are assigned to these parameters. Code that is written for compilers that ignore default parameter values must explicitly provide arguments for each default parameter. To maintain the behavior that you want across programming languages, methods that use default parameters should be replaced with method overloads that provide the default parameters.
+            The compiler ignores the values of default parameters for Managed Extension for C++ when it accesses managed code. The Visual Basic compiler supports methods that have default parameters that use the <code>Optional (Visual Basic)</code> keyword.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, replace the method that uses default parameters with method overloads that supply the default parameters.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:ReplaceRepetitiveArgumentsWithParamsArray}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182135.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182135.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="MarkEnumsWithFlags">
+    <configKey>CA1027</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1027: Mark enums with FlagsAttribute]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The values of a public enumeration are powers of two or are combinations of other values that are defined in the enumeration, and the <code>System.FlagsAttribute</code> attribute is not present. To reduce false positives, this rule does not report a violation for enumerations that have contiguous values.
+</p>
+<h2>Rule Description</h2>
+<p>
+            An enumeration is a value type that defines a set of related named constants. Apply <code>FlagsAttribute</code> to an enumeration when its named constants can be meaningfully combined. For example, consider an enumeration of the days of the week in an application that keeps track of which day's resources are available. If the availability of each resource is encoded by using the enumeration that has <code>FlagsAttribute</code> present, any combination of days can be represented. Without the attribute, only one day of the week can be represented.
+            For fields that store combinable enumerations, the individual enumeration values are treated as groups of bits in the field. Therefore, such fields are sometimes referred to as bit fields. To combine enumeration values for storage in a bit field, use the Boolean conditional operators. To test a bit field to determine whether a specific enumeration value is present, use the Boolean logical operators. For a bit field to store and retrieve combined enumeration values correctly, each value that is defined in the enumeration must be a power of two. Unless this is so, the Boolean logical operators will not be able to extract the individual enumeration values that are stored in the field.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, add <code>FlagsAttribute</code> to the enumeration.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Suppress a warning from this rule if you do not want the enumeration values to be combinable.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:DoNotMarkEnumsWithFlags}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182159.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182159.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="EnumStorageShouldBeInt32">
+    <configKey>CA1028</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1028: Enum storage should be Int32]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The underlying type of a public enumeration is not System.Int32.
+</p>
+<h2>Rule Description</h2>
+<p>
+            An enumeration is a value type that defines a set of related named constants. By default, the System.Int32 data type is used to store the constant value. Even though you can change this underlying type, it is not necessary or recommended for most scenarios. Note that no significant performance gain is achieved by using a data type that is smaller than Int32. If you cannot use the default data type, you should use one of the Common Language System (CLS)-compliant integral types, <code>Byte</code>, Int16, Int32, or Int64 to make sure that all values of the enumeration can be represented in CLS-compliant programming languages.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, unless size or compatibility issues exist, use Int32. For situations where Int32 is not large enough to hold the values, use Int64. If backward compatibility requires a smaller data type, use <code>Byte</code> or Int16.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Suppress a warning from this rule only if backward compatibility issues require it. In applications, failure to comply with this rule usually does not cause problems. In libraries, where language interoperability is required, failure to comply with this rule might adversely affect your users.
+</p>
+<h2>Example of a Violation</h2>
+
+<h3>Description</h3>
+<p>
+                The following example shows two enumerations that do not use the recommended underlying data type.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+
+namespace DesignLibrary
+{
+   [Flags]
+   public enum Days : uint
+   {
+      None        = 0,
+      Monday      = 1,
+      Tuesday     = 2,
+      Wednesday   = 4,
+      Thursday    = 8,
+      Friday      = 16,
+      All         = Monday| Tuesday | Wednesday | Thursday | Friday
+   }
+
+   public enum Color :sbyte
+   {
+      None        = 0,
+      Red         = 1,
+      Orange      = 3,
+      Yellow      = 4
+   }
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>Example of How to Fix</h2>
+
+<h3>Description</h3>
+<p>
+                The following example fixes the previous violation by changing the underlying data type to Int32.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+
+namespace Samples
+{
+    [Flags]
+    public enum Days : int
+    {
+        None        = 0,
+        Monday      = 1,
+        Tuesday     = 2,
+        Wednesday   = 4,
+        Thursday    = 8,
+        Friday      = 16,
+        All         = Monday| Tuesday | Wednesday | Thursday | Friday
+    }
+
+    public enum Color : int
+    {
+        None        = 0,
+        Red         = 1,
+        Orange      = 3,
+        Yellow      = 4
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:EnumsShouldHaveZeroValue}<br/>
+
+
+
+
+                {rule:fxcop:MarkEnumsWithFlags}<br/>
+
+
+
+
+                {rule:fxcop:DoNotMarkEnumsWithFlags}<br/>
+
+
+
+
+                {rule:fxcop:DoNotNameEnumValuesReserved}<br/>
+
+
+
+
+                {rule:fxcop:DoNotPrefixEnumValuesWithTypeName}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182147.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182147.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="UseEventsWhereAppropriate">
+    <configKey>CA1030</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1030: Use events where appropriate]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public, protected, or private method name begins with one of the following:
+            <ul>
+              <li>
+                AddOn
+              </li>
+              <li>
+                RemoveOn
+              </li>
+              <li>
+                Fire
+              </li>
+              <li>
+                Raise
+              </li>
+            </ul>
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule detects methods that have names that ordinarily would be used for events. Events follow the Observer or Publish-Subscribe design pattern; they are used when a state change in one object must be communicated to other objects. If a method gets called in response to a clearly defined state change, the method should be invoked by an event handler. Objects that call the method should raise events instead of calling the method directly.
+            Some common examples of events are found in user interface applications where a user action such as clicking a button causes a segment of code to execute. The .NET Framework event model is not limited to user interfaces; it should be used anywhere you must communicate state changes to one or more objects.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            If the method is called when the state of an object changes, you should consider changing the design to use the .NET Framework event model.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Suppress a warning from this rule if the method does not work with the .NET Framework event model.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182177.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182177.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotCatchGeneralExceptionTypes">
+    <configKey>CA1031</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1031: Do not catch general exception types]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A general exception such as <code>System.Exception</code> or <code>System.SystemException</code> is caught in a <code>catch</code> statement, or a general catch clause such as catch() is used.
+</p>
+<h2>Rule Description</h2>
+<p>
+            General exceptions should not be caught.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, catch a more specific exception, or rethrow the general exception as the last statement in the <code>catch</code> block.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule. Catching general exception types can hide run-time problems from the library user and can make debugging more difficult.
+
+
+
+
+
+                    Note
+
+
+
+
+                    Starting with the .NET Framework 4, the common language runtime (CLR) no longer delivers corrupted state exceptions that occur in the operating system and managed code, such as access violations in Windows, to be handled by managed code. If you want to compile an application in the .NET Framework 4 or later versions and maintain handling of corrupted state exceptions, you can apply the <code>HandleProcessCorruptedStateExceptionsAttribute</code> attribute to the method that handles the corrupted state exception.
+
+
+
+
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:RethrowToPreserveStackDetails}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182137.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182137.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ImplementStandardExceptionConstructors">
+    <configKey>CA1032</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1032: Implement standard exception constructors]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type extends <code>System.Exception</code> and does not declare all the required constructors.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Exception types must implement the following constructors:
+            <ul>
+              <li>
+                public NewException()
+              </li>
+              <li>
+                public NewException(string)
+              </li>
+              <li>
+                public NewException(string, Exception)
+              </li>
+              <li>
+                protected or private NewException(SerializationInfo, StreamingContext)
+              </li>
+            </ul>
+            Failure to provide the full set of constructors can make it difficult to correctly handle exceptions. For example, the constructor that has the signature NewException(string, Exception) is used to create exceptions that are caused by other exceptions. Without this constructor you cannot create and throw an instance of your custom exception that contains an inner (nested) exception, which is what managed code should do in such a situation. The first three exception constructors are public by convention. The fourth constructor is protected in unsealed classes, and private in sealed classes. For more information, see {rule:fxcop:ImplementSerializationConstructors}
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, add the missing constructors to the exception, and make sure that they have the correct accessibility.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule when the violation is caused by using a different access level for the public constructors.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182151.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182151.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="InterfaceMethodsShouldBeCallableByChildTypes">
+    <configKey>CA1033</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1033: Interface methods should be callable by child types]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An unsealed externally visible type provides an explicit method implementation of a public interface and does not provide an alternative externally visible method that has the same name.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Consider a base type that explicitly implements a public interface method. A type that derives from the base type can access the inherited interface method only through a reference to the current instance (<code>this</code> in C#) that is cast to the interface. If the derived type re-implements (explicitly) the inherited interface method, the base implementation can no longer be accessed. The call through the current instance reference will invoke the derived implementation; this causes recursion and an eventual stack overflow.
+            This rule does not report a violation for an explicit implementation of <code>IDisposable.Dispose</code> when an externally visible Close() or System.IDisposable.Dispose(Boolean) method is provided.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, implement a new method that exposes the same functionality and is visible to derived types or change to a nonexplicit implementation. If a breaking change is acceptable, an alternative is to make the type sealed.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if an externally visible method is provided that has the same functionality but a different name than the explicitly implemented method.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182153.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182153.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="NestedTypesShouldNotBeVisible">
+    <configKey>CA1034</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1034: Nested types should not be visible]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An externally visible type contains an externally visible type declaration. Nested enumerations and protected types are exempt from this rule.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A nested type is a type declared within the scope of another type. Nested types are useful for encapsulating private implementation details of the containing type. Used for this purpose, nested types should not be externally visible.
+            Do not use externally visible nested types for logical grouping or to avoid name collisions; instead, use namespaces.
+            Nested types include the notion of member accessibility, which some programmers do not understand clearly.
+            Protected types can be used in subclasses and nested types in advance customization scenarios.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            If you do not intend the nested type to be externally visible, change the type's accessibility. Otherwise, remove the nested type from its parent. If the purpose of the nesting is to categorize the nested type, use a namespace to create the hierarchy instead.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182162.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182162.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ICollectionImplementationsHaveStronglyTypedMembers">
+    <configKey>CA1035</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1035: ICollection implementations have strongly typed members]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected type implements <code>System.Collections.ICollection</code> but does not provide a strongly typed method for <code>ICollection.CopyTo</code>. The strongly typed version of <code>CopyTo</code> must accept two parameters and cannot have a <code>System.Array</code> or an array of <code>System.Object</code> as its first parameter.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule requires <code>ICollection</code> implementations to provide strongly typed members so that users are not required to cast arguments to the <code>Object</code> type when they use the functionality that is provided by the interface. This rule assumes that the type that implements <code>ICollection</code> does so to manage a collection of instances of a type that is stronger than <code>Object</code>.
+
+
+                <code>ICollection</code>
+               implements the <code>System.Collections.IEnumerable</code> interface. If the objects in the collection extend <code>System.ValueType</code>, you must provide a strongly typed member for <code>GetEnumerator</code> to avoid the decrease in performance that is caused by boxing. This is not required when the objects of the collection are a reference type.
+            To implement a strongly typed version of an interface member, implement the interface members explicitly by using names in the form InterfaceName.InterfaceMemberName, such as <code>CopyTo</code>. The explicit interface members use the data types that are declared by the interface. Implement the strongly typed members by using the interface member name, such as <code>CopyTo</code>. Declare the strongly typed members as public, and declare parameters and return values to be of the strong type that is managed by the collection. The strong types replace weaker types such as <code>Object</code> and <code>Array</code> that are declared by the interface.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, implement the interface member explicitly (declare it as <code>CopyTo</code>). Add the public strongly typed member, declared as CopyTo, and have it take a strongly typed array as its first parameter.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Suppress a warning from this rule if you implement a new object-based collection, such as a binary tree, where types that extend the new collection determine the strong type. These types should comply with this rule and expose strongly typed members.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:EnumeratorsShouldBeStronglyTyped}<br/>
+
+
+
+
+                {rule:fxcop:ListsAreStronglyTyped}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/49stb304.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/49stb304.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="OverrideMethodsOnComparableTypes">
+    <configKey>CA1036</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1036: Override methods on comparable types]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected type implements the <code>System.IComparable</code> interface and does not override <code>Object.Equals</code> or does not overload the language-specific operator for equality, inequality, less than, or greater than. The rule does not report a violation if the type inherits only an implementation of the interface.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Types that define a custom sort order implement the <code>IComparable</code> interface. The <code>CompareTo</code> method returns an integer value that indicates the correct sort order for two instances of the type. This rule identifies types that set a sort order; this implies that the ordinary meaning of equality, inequality, less than, and greater than do not apply. When you provide an implementation of <code>IComparable</code>, you must usually also override <code>Equals</code> so that it returns values that are consistent with <code>CompareTo</code>. If you override <code>Equals</code> and are coding in a language that supports operator overloads, you should also provide operators that are consistent with <code>Equals</code>.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, override <code>Equals</code>. If your programming language supports operator overloading, supply the following operators:
+            <ul>
+              <li>
+                op_Equality
+              </li>
+              <li>
+                op_Inequality
+              </li>
+              <li>
+                op_LessThan
+              </li>
+              <li>
+                op_GreaterThan
+              </li>
+            </ul>
+            In C#, the tokens that are used to represent these operators are as follows: ==, !=, &lt;, and &gt;.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule when the violation is caused by missing operators and your programming language does not support operator overloading, as is the case with Visual Basic .NET. It is also safe to suppress a warning for from this rule when it fires on equality operators other than op_Equality if you determine that implementing the operators does not make sense in your application context. However, you should always over op_Equality and the == operator if you override Object.Equals.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182163.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182163.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="EnumeratorsShouldBeStronglyTyped">
+    <configKey>CA1038</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1038: Enumerators should be strongly typed]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected type implements <code>System.Collections.IEnumerator</code> but does not provide a strongly typed version of the <code>IEnumerator.Current</code> property. Types that are derived from the following types are exempt from this rule:
+            <ul>
+              <li>
+
+
+                    <code>System.Collections.CollectionBase</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.Collections.DictionaryBase</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.Collections.ReadOnlyCollectionBase</code>
+
+
+              </li>
+            </ul>
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule requires <code>IEnumerator</code> implementations to also provide a strongly typed version of the <code>Current</code> property so that users are not required to cast the return value to the strong type when they use the functionality that is provided by the interface. This rule assumes that the type that implements <code>IEnumerator</code> contains a collection of instances of a type that is stronger than <code>Object</code>.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, implement the interface property explicitly (declare it as IEnumerator.Current). Add a public strongly typed version of the property, declared as Current, and have it return a strongly typed object.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Suppress a warning from this rule when you implement an object-based enumerator for use with an object-based collection, such as a binary tree. Types that extend the new collection will define the strongly typed enumerator and expose the strongly typed property.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                <code>CA1035: ICollection implementations have strongly typed members</code>
+
+
+
+
+                {rule:fxcop:ListsAreStronglyTyped}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182148.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182148.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ListsAreStronglyTyped">
+    <configKey>CA1039</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1039: Lists are strongly typed]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The public or protected type implements <code>System.Collections.IList</code> but does not provide a strongly typed method for one or more of the following:
+            <ul>
+              <li>
+                IList.Item
+              </li>
+              <li>
+                IList.Add
+              </li>
+              <li>
+                IList.Contains
+              </li>
+              <li>
+                IList.IndexOf
+              </li>
+              <li>
+                IList.Insert
+              </li>
+              <li>
+                IList.Remove
+              </li>
+            </ul>
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule requires <code>IList</code> implementations to provide strongly typed members so that users are not required to cast arguments to the <code>System.Object</code> type when they use the functionality that is provided by the interface. The <code>IList</code> interface is implemented by collections of objects that can be accessed by index. This rule assumes that the type that implements <code>IList</code> does this to manage a collection of instances of a type that is stronger than <code>Object</code>.
+
+
+                <code>IList</code>
+               implements the <code>System.Collections.ICollection</code> and <code>System.Collections.IEnumerable</code> interfaces. If you implement <code>IList</code>, you must provide the required strongly typed members for <code>ICollection</code>. If the objects in the collection extend <code>System.ValueType</code>, you must provide a strongly typed member for <code>GetEnumerator</code> to avoid the decrease in performance that is caused by boxing; this is not required when the objects of the collection are a reference type.
+            To comply with this rule, implement the interface members explicitly by using names in the form InterfaceName.InterfaceMemberName, such as <code>Add</code>. The explicit interface members use the data types that are declared by the interface. Implement the strongly typed members by using the interface member name, such as Add. Declare the strongly typed members as public, and declare parameters and return values to be of the strong type that is managed by the collection. The strong types replace weaker types such as <code>Object</code> and <code>Array</code> that are declared by the interface.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, explicitly implement <code>IList</code> members and provide strongly typed alternatives for the members that were noted previously. For code that correctly implements the <code>IList</code> interface and provides the required strongly typed members, see the following example.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Suppress a warning from this rule when you implement a new object-based collection, such as a linked list, where types that extend the new collection determine the strong type. These types should comply with this rule and expose strongly typed members.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                <code>CA1035: ICollection implementations have strongly typed members</code>
+
+
+
+
+                {rule:fxcop:EnumeratorsShouldBeStronglyTyped}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182154.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182154.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AvoidEmptyInterfaces">
+    <configKey>CA1040</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1040: Avoid empty interfaces]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The interface does not declare any members or implement two or more other interfaces.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Interfaces define members that provide a behavior or usage contract. The functionality that is described by the interface can be adopted by any type, regardless of where the type appears in the inheritance hierarchy. A type implements an interface by providing implementations for the members of the interface. An empty interface does not define any members. Therefore, it does not define a contract that can be implemented.
+            If your design includes empty interfaces that types are expected to implement, you are probably using an interface as a marker or a way to identify a group of types. If this identification will occur at run time, the correct way to accomplish this is to use a custom attribute. Use the presence or absence of the attribute, or the properties of the attribute, to identify the target types. If the identification must occur at compile time, then it is acceptable to use an empty interface.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Remove the interface or add members to it. If the empty interface is being used to label a set of types, replace the interface with a custom attribute.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule when the interface is used to identify a set of types at compile time.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182128.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182128.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ProvideObsoleteAttributeMessage">
+    <configKey>CA1041</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1041: Provide ObsoleteAttribute message]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type or member is marked by using a <code>System.ObsoleteAttribute</code> attribute that does not have its <code>ObsoleteAttribute.Message</code> property specified.
+</p>
+<h2>Rule Description</h2>
+<p>
+
+
+                <code>ObsoleteAttribute</code>
+               is used to mark deprecated library types and members. Library consumers should avoid the use of any type or member that is marked obsolete. This is because it might not be supported and will eventually be removed from later versions of the library. When a type or member marked by using <code>ObsoleteAttribute</code> is compiled, the <code>Message</code> property of the attribute is displayed. This gives the user information about the obsolete type or member. This information generally includes how long the obsolete type or member will be supported by the library designers and the preferred replacement to use.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, add the message parameter to the <code>ObsoleteAttribute</code> constructor.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule because the <code>Message</code> property provides critical information about the obsolete type or member.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182166.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182166.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="UseIntegralOrStringArgumentForIndexers">
+    <configKey>CA1043</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1043: Use integral or string argument for indexers]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected type contains a public or protected indexer that uses an index type other than System.Int32, System.Int64, <code>System.Object</code>, or <code>System.String</code>.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Indexers, that is, indexed properties, should use integer or string types for the index. These types are typically used for indexing data structures and increase the usability of the library. Use of the <code>Object</code> type should be restricted to those cases where the specific integer or string type cannot be specified at design time. If the design requires other types for the index, reconsider whether the type represents a logical data store. If it does not represent a logical data store, use a method.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the index to an integer or string type, or use a method instead of the indexer.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Suppress a warning from this rule only after carefully considering the need for the nonstandard indexer.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:IndexersShouldNotBeMultidimensional}<br/>
+
+
+
+
+                {rule:fxcop:UsePropertiesWhereAppropriate}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182180.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182180.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="PropertiesShouldNotBeWriteOnly">
+    <configKey>CA1044</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1044: Properties should not be write only]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The public or protected property has a set accessor but does not have a get accessor.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Get accessors provide read access to a property and set accessors provide write access. Although it is acceptable and often necessary to have a read-only property, the design guidelines prohibit the use of write-only properties. This is because letting a user set a value and then preventing the user from viewing the value does not provide any security. Also, without read access, the state of shared objects cannot be viewed, which limits their usefulness.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, add a get accessor to the property. Alternatively, if the behavior of a write-only property is necessary, consider converting this property to a method.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is strongly recommended that you do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182165.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182165.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotPassTypesByReference">
+    <configKey>CA1045</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1045: Do not pass types by reference]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected method in a public type has a <code>ref</code> parameter that takes a primitive type, a reference type, or a value type that is not one of the built-in types.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Passing types by reference (using <code>out</code> or <code>ref</code>) requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between <code>out</code> and <code>ref</code> parameters is not widely understood.
+            When a reference type is passed "by reference," the method intends to use the parameter to return a different instance of the object. (Passing a reference type by reference is also known as using a double pointer, pointer to a pointer, or double indirection.) Using the default calling convention, which is pass "by value," a parameter that takes a reference type already receives a pointer to the object. The pointer, not the object to which it points, is passed by value. Passing by value means that the method cannot change the pointer to have it point to a new instance of the reference type, but can change the contents of the object to which it points. For most applications this is sufficient and yields the behavior that you want.
+            If a method must return a different instance, use the return value of the method to accomplish this. See the <code>System.String</code> class for a variety of methods that operate on strings and return a new instance of a string. By using this model, it is left to the caller to decide whether the original object is preserved.
+            Although return values are commonplace and heavily used, the correct application of <code>out</code> and <code>ref</code> parameters requires intermediate design and coding skills. Library architects who design for a general audience should not expect users to master working with <code>out</code> or <code>ref</code> parameters.
+
+
+
+
+
+                    Note
+
+
+
+
+                    When you work with parameters that are large structures, the additional resources that are required to copy these structures could cause a performance effect when you pass by value. In these cases, you might consider using <code>ref</code> or <code>out</code> parameters.
+
+
+
+
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule that is caused by a value type, have the method return the object as its return value. If the method must return multiple values, redesign it to return a single instance of an object that holds the values.
+            To fix a violation of this rule that is caused by a reference type, make sure that the behavior that you want is to return a new instance of the reference. If it is, the method should use its return value to do this.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule; however, this design could cause usability issues.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:AvoidOutParameters}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182146.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182146.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotOverloadOperatorEqualsOnReferenceTypes">
+    <configKey>CA1046</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1046: Do not overload operator equals on reference types]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or nested public reference type overloads the equality operator.
+</p>
+<h2>Rule Description</h2>
+<p>
+            For reference types, the default implementation of the equality operator is almost always correct. By default, two references are equal only if they point to the same object.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, remove the implementation of the equality operator.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule when the reference type behaves like a built-in value type. If it is meaningful to do addition or subtraction on instances of the type, it is probably correct to implement the equality operator and suppress the violation.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:OverloadOperatorEqualsOnOverloadingAddAndSubtract}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182145.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182145.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotDeclareProtectedMembersInSealedTypes">
+    <configKey>CA1047</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1047: Do not declare protected members in sealed types]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public type is <code>sealed</code> (<code>NotInheritable</code> in Visual basic) and declares a protected member or a protected nested type. This rule does not report violations for <code>Finalize</code> methods, which must follow this pattern.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Types declare protected members so that inheriting types can access or override the member. By definition, you cannot inherit from a sealed type, which means that protected methods on sealed types cannot be called.
+            The C# compiler issues a warning for this error.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the access level of the member to private, or make the type inheritable.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule. Leaving the type in its current state can cause maintenance issues and does not provide any benefits.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182138.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182138.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotDeclareVirtualMembersInSealedTypes">
+    <configKey>CA1048</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1048: Do not declare virtual members in sealed types]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public type is sealed and declares a method that is both <code>virtual</code> (<code>Overridable</code> in Visual Basic) and not final. This rule does not report violations for delegate types, which must follow this pattern.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Types declare methods as virtual so that inheriting types can override the implementation of the virtual method. By definition, you cannot inherit from a sealed type, making a virtual method on a sealed type meaningless.
+            The Visual Basic .NET and C# compilers do not allow types to violate this rule.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, make the method non-virtual or make the type inheritable.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule. Leaving the type in its current state can cause maintenance issues and does not provide any benefits.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182140.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182140.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="TypesThatOwnNativeResourcesShouldBeDisposable">
+    <configKey>CA1049</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1049: Types that own native resources should be disposable]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type references a <code>System.IntPtr</code> field, a <code>System.UIntPtr</code> field, or a <code>System.Runtime.InteropServices.HandleRef</code> field, but does not implement <code>System.IDisposable</code>.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule assumes that <code>IntPtr</code>, <code>UIntPtr</code>, and <code>HandleRef</code> fields store pointers to unmanaged resources. Types that allocate unmanaged resources should implement <code>IDisposable</code> to let callers to release those resources on demand and shorten the lifetimes of the objects that hold the resources.
+            The recommended design pattern to clean up unmanaged resources is to provide both an implicit and an explicit means to free those resources by using the <code>Object.Finalize</code> method and the <code>IDisposable.Dispose</code> method, respectively. The garbage collector calls the <code>Finalize</code> method of an object at some indeterminate time after the object is determined to be no longer reachable. After <code>Finalize</code> is called, an additional garbage collection is required to free the object. The <code>Dispose</code> method allows the caller to explicitly release resources on demand, earlier than the resources would be released if left to the garbage collector. After it cleans up the unmanaged resources, <code>Dispose</code> should call the <code>GC.SuppressFinalize</code> method to let the garbage collector know that <code>Finalize</code> no longer has to be called; this eliminates the need for the additional garbage collection and shortens the lifetime of the object.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, implement <code>IDisposable</code>.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if the type does not reference an unmanaged resource. Otherwise, do not suppress a warning from this rule because failure to implement <code>IDisposable</code> can cause unmanaged resources to become unavailable or underused.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:CallGCKeepAliveWhenUsingNativeResources}<br/>
+
+
+
+
+                {rule:fxcop:CallGCSuppressFinalizeCorrectly}<br/>
+
+
+
+
+                {rule:fxcop:DisposableTypesShouldDeclareFinalizer}<br/>
+
+
+
+
+                {rule:fxcop:TypesThatOwnDisposableFieldsShouldBeDisposable}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182173.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182173.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DeclareTypesInNamespaces">
+    <configKey>CA1050</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1050: Declare types in namespaces]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected type is defined outside the scope of a named namespace.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Types are declared in namespaces to prevent name collisions, and as a way to organize related types in an object hierarchy. Types that are outside any named namespace are in a global namespace that cannot be referenced in code.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, place the type in a namespace.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Although you never have to suppress a warning from this rule, it is safe to do this when the assembly will never be used together with other assemblies.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182134.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182134.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotDeclareVisibleInstanceFields">
+    <configKey>CA1051</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1051: Do not declare visible instance fields]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An externally visible type has an externally visible instance field.
+</p>
+<h2>Rule Description</h2>
+<p>
+            The primary use of a field should be as an implementation detail. Fields should be <code>private</code> or <code>internal</code> and should be exposed by using properties. It is as easy to access a property as it is to access a field, and the code in the accessors of a property can change as the features of the type expand without introducing breaking changes. Properties that just return the value of a private or internal field are optimized to perform on par with accessing a field; very little performance gain is associated with the use of externally visible fields over properties.
+            Externally visible refers to <code>public</code>, <code>protected</code>, and <code>protected internal</code> (<code>Public</code>, <code>Protected</code>, and <code>Protected Friend</code> in Visual Basic) accessibility levels.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, make the field <code>private</code> or <code>internal</code> and expose it by using an externally visible property.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule. Externally visible fields do not provide any benefits that are unavailable to properties. Additionally, public fields cannot be protected by Link Demands. See {rule:fxcop:SecuredTypesShouldNotExposeFields}.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:SecuredTypesShouldNotExposeFields}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182141.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182141.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="StaticHolderTypesShouldBeSealed">
+    <configKey>CA1052</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1052: Static holder types should be sealed]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected type contains only static members and is not declared with the <code>sealed (C# Reference)</code> (NotInheritable (Visual Basic)) modifier.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule assumes that a type that contains only static members is not designed to be inherited, because the type does not provide any functionality that can be overridden in a derived type. A type that is not meant to be inherited should be marked with the <code>sealed</code> modifier to prohibit its use as a base type.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, mark the type as <code>sealed</code>. If you are targeting .NET Framework 2.0 or earlier, a better approach is to mark the type as <code>static</code>. In this manner, you avoid having to declare a private constructor to prevent the class from being created.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Suppress a warning from this rule only if the type is designed to be inherited. The absence of the <code>sealed</code> modifier suggests that the type is useful as a base type.
+</p>
+<h2>Example of a Violation</h2>
+
+<h3>Description</h3>
+<p>
+                The following example shows a type that violates the rule.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+
+namespace DesignLibrary
+{
+    public class StaticMembers
+    {
+        static int someField;
+
+        public static int SomeProperty
+        {
+            get
+            {
+                return someField;
+            }
+            set
+            {
+                someField = value;
+            }
+        }
+
+        StaticMembers() {}
+
+        public static void SomeMethod() {}
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>Fix with the Static Modifier</h2>
+
+<h3>Description</h3>
+<p>
+                The following example shows how to fix a violation of this rule by marking the type with the <code>static</code> modifier.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+
+namespace DesignLibrary
+{
+    public static class StaticMembers
+    {
+        private static int someField;
+
+        public static int SomeProperty
+        {
+            get { return someField; }
+            set { someField = value; }
+        }
+
+        public static void SomeMethod()
+        {
+        }
+
+        public static event SomeDelegate SomeEvent;
+    }
+
+    public delegate void SomeDelegate();
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:StaticHolderTypesShouldNotHaveConstructors}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182168.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182168.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="StaticHolderTypesShouldNotHaveConstructors">
+    <configKey>CA1053</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1053: Static holder types should not have constructors]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or nested public type declares only static members and has a public or protected default constructor.
+</p>
+<h2>Rule Description</h2>
+<p>
+            The constructor is unnecessary because calling static members does not require an instance of the type. Also, because the type does not have non-static members, creating an instance does not provide access to any of the type's members.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, remove the default constructor or make it private.
+
+
+
+
+
+                    Note
+
+
+
+
+                    Some compilers automatically create a public default constructor if the type does not define any constructors. If this is the case with your type, add a private default constructor to eliminate the violation.
+
+
+
+
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule. The presence of the constructor suggests that the type is not a static type.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182169.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182169.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="UriParametersShouldNotBeStrings">
+    <configKey>CA1054</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1054: URI parameters should not be strings]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type declares a method with a string parameter whose name contains "uri", "Uri", "urn", "Urn", "url", or "Url" and the type does not declare a corresponding overload that takes a <code>System.Uri</code> parameter.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule splits the parameter name into tokens based on the camel casing convention and checks whether each token equals "uri", "Uri", "urn", "Urn", "url", or "Url". If there is a match, the rule assumes that the parameter represents a uniform resource identifier (URI). A string representation of a URI is prone to parsing and encoding errors, and can lead to security vulnerabilities. If a method takes a string representation of a URI, a corresponding overload should be provided that takes an instance of the <code>Uri</code> class, which provides these services in a safe and secure manner.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the parameter to a <code>Uri</code> type; this is a breaking change. Alternately, provide an overload of the method which takes a <code>Uri</code> parameter; this is a nonbreaking change.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if the parameter does not represent a URI.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:UriPropertiesShouldNotBeStrings}<br/>
+
+
+
+
+                {rule:fxcop:UriReturnValuesShouldNotBeStrings}<br/>
+
+
+
+
+                {rule:fxcop:PassSystemUriObjectsInsteadOfStrings}<br/>
+
+
+
+
+                {rule:fxcop:StringUriOverloadsCallSystemUriOverloads}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182174.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182174.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="UriReturnValuesShouldNotBeStrings">
+    <configKey>CA1055</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1055: URI return values should not be strings]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The name of a method contains "uri", "Uri", "urn", "Urn", "url", or "Url", and the method returns a string.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule splits the method name into tokens based on the Pascal casing convention and checks whether each token equals "uri", "Uri", "urn", "Urn", "url", or "Url". If there is a match, the rule assumes that the method returns a uniform resource identifier (URI). A string representation of a URI is prone to parsing and encoding errors, and can lead to security vulnerabilities. The <code>System.Uri</code> class provides these services in a safe and secure manner.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the return type to a <code>Uri</code>.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if the return value does not represent a URI.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:UriPropertiesShouldNotBeStrings}<br/>
+
+
+
+
+                {rule:fxcop:UriParametersShouldNotBeStrings}<br/>
+
+
+
+
+                {rule:fxcop:PassSystemUriObjectsInsteadOfStrings}<br/>
+
+
+
+
+                {rule:fxcop:StringUriOverloadsCallSystemUriOverloads}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182176.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182176.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="UriPropertiesShouldNotBeStrings">
+    <configKey>CA1056</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1056: URI properties should not be strings]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type declares a string property whose name contains "uri", "Uri", "urn", "Urn", "url", or "Url".
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule splits the property name into tokens based on the Pascal casing convention and checks whether each token equals "uri", "Uri", "urn", "Urn", "url", or "Url". If there is a match, the rule assumes that the property represents a uniform resource identifier (URI). A string representation of a URI is prone to parsing and encoding errors, and can lead to security vulnerabilities. The <code>System.Uri</code> class provides these services in a safe and secure manner.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the property to a <code>Uri</code> type.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if the property does not represent a URI.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:UriParametersShouldNotBeStrings}<br/>
+
+
+
+
+                {rule:fxcop:UriReturnValuesShouldNotBeStrings}<br/>
+
+
+
+
+                {rule:fxcop:PassSystemUriObjectsInsteadOfStrings}<br/>
+
+
+
+
+                {rule:fxcop:StringUriOverloadsCallSystemUriOverloads}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182175.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182175.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="StringUriOverloadsCallSystemUriOverloads">
+    <configKey>CA1057</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1057: String URI overloads call System.Uri overloads]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type declares method overloads that differ only by the replacement of a string parameter with a <code>System.Uri</code> parameter, and the overload that takes the string parameter does not call the overload that takes the <code>Uri</code> parameter.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Because the overloads differ only by the string/<code>Uri</code> parameter, the string is assumed to represent a uniform resource identifier (URI). A string representation of a URI is prone to parsing and encoding errors, and can lead to security vulnerabilities. The <code>Uri</code> class provides these services in a safe and secure manner. To reap the benefits of the <code>Uri</code> class, the string overload should call the <code>Uri</code> overload using the string argument.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Re-implement the method that uses the string representation of the URI so that it creates an instance of the <code>Uri</code> class using the string argument, and then passes the <code>Uri</code> object to the overload that has the <code>Uri</code> parameter.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if the string parameter does not represent a URI.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:PassSystemUriObjectsInsteadOfStrings}<br/>
+
+
+
+
+                {rule:fxcop:UriPropertiesShouldNotBeStrings}<br/>
+
+
+
+
+                {rule:fxcop:UriParametersShouldNotBeStrings}<br/>
+
+
+
+
+                {rule:fxcop:UriReturnValuesShouldNotBeStrings}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182170.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182170.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="TypesShouldNotExtendCertainBaseTypes">
+    <configKey>CA1058</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1058: Types should not extend certain base types]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An externally visible type extends certain base types. Currently, this rule reports types that derive from the following types:
+            <ul>
+              <li>
+
+
+                    <code>System.ApplicationException</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.Xml.XmlDocument</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.Collections.CollectionBase</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.Collections.DictionaryBase</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.Collections.Queue</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.Collections.ReadOnlyCollectionBase</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.Collections.SortedList</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.Collections.Stack</code>
+
+
+              </li>
+            </ul>
+</p>
+<h2>Rule Description</h2>
+<p>
+            For .NET Framework version 1, it was recommended to derive new exceptions from <code>ApplicationException</code>. The recommendation has changed and new exceptions should derive from <code>System.Exception</code> or one of its subclasses in the <code>System</code> namespace.
+            Do not create a subclass of <code>XmlDocument</code> if you want to create an XML view of an underlying object model or data source.
+
+
+
+
+
+
+                    Non-generic Collections
+
+
+
+
+
+
+
+
+
+
+                Use and/or extend generic collections whenever possible. Do not extend non-generic collections in your code, unless you shipped it previously.
+
+                  Examples of Incorrect Usage
+
+
+
+
+
+
+
+
+
+
+            <pre>
+public class MyCollection : CollectionBase
+{
+}
+
+public class MyReadOnlyCollection : ReadOnlyCollectionBase
+{
+}
+</pre>
+
+
+
+
+Examples of Correct Usage
+
+
+
+
+
+
+
+
+
+            <pre>
+public class MyCollection : Collection&lt;T&gt;
+{
+}
+
+public class MyReadOnlyCollection : ReadOnlyCollection&lt;T&gt;
+{
+}
+</pre>
+
+
+
+
+
+
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, derive the type from a different base type or a generic collection.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule for violations about <code>ApplicationException</code>. It is safe to suppress a warning from this rule for violations about <code>XmlDocument</code>. It is safe to suppress a warning about a non-generic collection if the code was released previously.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182171.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182171.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="MembersShouldNotExposeCertainConcreteTypes">
+    <configKey>CA1059</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1059: Members should not expose certain concrete types]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An externally visible member is a certain concrete type or exposes certain concrete types through one of its parameters or return value. Currently, this rule reports exposure of the following concrete types:
+            <ul>
+              <li>
+                A type derived from <code>System.Xml.XmlNode</code>.
+              </li>
+            </ul>
+</p>
+<h2>Rule Description</h2>
+<p>
+            A concrete type is a type that has a complete implementation and therefore can be instantiated. To allow widespread use of the member, replace the concrete type with the suggested interface. This allows the member to accept any type that implements the interface or be used where a type that implements the interface is expected.
+            The following table lists the targeted concrete types and their suggested replacements.
+
+
+
+
+
+
+
+                    Concrete type
+
+
+                    Replacement
+
+
+
+
+
+
+                        <code>XPathDocument</code>
+
+
+
+
+
+
+                        <code>System.Xml.XPath.IXPathNavigable</code>
+                      .
+                    Using the interface decouples the member from a specific implementation of an XML data source.
+
+
+
+
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the concrete type to the suggested interface.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a message from this rule if the specific functionality provided by the concrete type is required.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                <code>CA1011: Consider passing base types as parameters</code>
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182160.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182160.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="MovePInvokesToNativeMethodsClass">
+    <configKey>CA1060</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1060: Move P/Invokes to NativeMethods class]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method uses Platform Invocation Services to access unmanaged code and is not a member of one of the NativeMethods classes.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Platform Invocation methods, such as those that are marked by using the <code>System.Runtime.InteropServices.DllImportAttribute</code> attribute, or methods that are defined by using the <code>Declare</code> keyword in Visual Basic, access unmanaged code. These methods should be in one of the following classes:
+            <ul>
+              <li>
+
+                  NativeMethods - This class does not suppress stack walks for unmanaged code permission. (<code>System.Security.SuppressUnmanagedCodeSecurityAttribute</code> must not be applied to this class.) This class is for methods that can be used anywhere because a stack walk will be performed.
+              </li>
+              <li>
+
+                  SafeNativeMethods - This class suppresses stack walks for unmanaged code permission. (<code>System.Security.SuppressUnmanagedCodeSecurityAttribute</code> is applied to this class.) This class is for methods that are safe for anyone to call. Callers of these methods are not required to perform a full security review to make sure that the usage is secure because the methods are harmless for any caller.
+              </li>
+              <li>
+
+                  UnsafeNativeMethods - This class suppresses stack walks for unmanaged code permission. (<code>System.Security.SuppressUnmanagedCodeSecurityAttribute</code> is applied to this class.) This class is for methods that are potentially dangerous. Any caller of these methods must perform a full security review to make sure that the usage is secure because no stack walk will be performed.
+              </li>
+            </ul>
+            These classes are declared as <code>internal</code> (<code>Friend</code>, in Visual Basic) and declare a private constructor to prevent new instances from being created. The methods in these classes should be <code>static</code> and <code>internal</code> (<code>Shared</code> and <code>Friend</code> in Visual Basic).
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, move the method to the appropriate NativeMethods class. For most applications, moving P/Invokes to a new class that is named NativeMethods is enough.
+            However, if you are developing libraries for use in other applications, you should consider defining two other classes that are called SafeNativeMethods and UnsafeNativeMethods. These classes resemble the NativeMethods class; however, they are marked by using a special attribute called SuppressUnmanagedCodeSecurityAttribute. When this attribute is applied, the runtime does not perform a full stack walk to make sure that all callers have the UnmanagedCode permission. The runtime ordinarily checks for this permission at startup. Because the check is not performed, it can greatly improve performance for calls to these unmanaged methods, It also enables code that has limited permissions to call these methods.
+            However, you should use this attribute with great care. It can have serious security implications if it is implemented incorrectly..
+            For information about how to implement the methods, see the NativeMethods Example, SafeNativeMethods Example, and UnsafeNativeMethods Example.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Example</h2>
+
+<h3>Description</h3>
+<p>
+                Because the NativeMethods class should not be marked by using SuppressUnmanagedCodeSecurityAttribute, P/Invokes that are put in it will require UnmanagedCode permission. Because most applications run from the local computer and run together with full trust, this is usually not a problem. However, if you are developing reusable libraries, you should consider defining a SafeNativeMethods or UnsafeNativeMethods class.
+                The following example shows an Interaction.Beep method that wraps the MessageBeep function from user32.dll. The MessageBeep P/Invoke is put in the NativeMethods class.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+using System.Runtime.InteropServices;
+using System.ComponentModel;
+
+public static class Interaction
+{
+    // Callers require Unmanaged permission         
+    public static void Beep()
+    {
+        // No need to demand a permission as callers of Interaction.Beep             
+        // will require UnmanagedCode permission             
+        if (!NativeMethods.MessageBeep(-1))
+            throw new Win32Exception();
+    }
+}
+
+internal static class NativeMethods
+{
+    [DllImport("user32.dll", CharSet = CharSet.Auto)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool MessageBeep(int uType);
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>SafeNativeMethods Example</h2>
+
+<h3>Description</h3>
+<p>
+                P/Invoke methods that can be safely exposed to any application and that do not have any side effects should be put in a class that is named SafeNativeMethods. You do not have to demand permissions and you do not have to pay much attention to where they are called from.
+                The following example shows an Environment.TickCount property that wraps the GetTickCount function from kernel32.dll.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+public static class Environment
+{
+    // Callers do not require UnmanagedCode permission        
+    public static int TickCount
+    {
+        get
+        {
+            // No need to demand a permission in place of                
+            // UnmanagedCode as GetTickCount is considered               
+            // a safe method               
+            return SafeNativeMethods.GetTickCount();
+        }
+    }
+}
+
+[SuppressUnmanagedCodeSecurityAttribute]
+internal static class SafeNativeMethods
+{
+    [DllImport("kernel32.dll", CharSet=CharSet.Auto, ExactSpelling=true)]
+    internal static extern int GetTickCount();
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>UnsafeNativeMethods Example</h2>
+
+<h3>Description</h3>
+<p>
+                P/Invoke methods that cannot be safely called and that could cause side effects should be put in a class that is named UnsafeNativeMethods. These methods should be rigorously checked to make sure that they are not exposed to the user unintentionally. The rule {rule:fxcop:ReviewSuppressUnmanagedCodeSecurityUsage} can help with this. Alternatively, the methods should have another permission that is demanded instead of UnmanagedCode when they use them.
+                The following example shows a Cursor.Hide method that wraps the ShowCursor function from user32.dll.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Security.Permissions;
+
+public static class Cursor
+{
+    // Callers do not require UnmanagedCode permission, however,        
+    // they do require UIPermissionWindow.AllWindows        
+    public static void Hide()
+    {
+        // Need to demand an appropriate permission            
+        // in  place of UnmanagedCode permission as             
+        // ShowCursor is not considered a safe method            
+        new UIPermission(UIPermissionWindow.AllWindows).Demand();
+        UnsafeNativeMethods.ShowCursor(false);
+    }
+}
+
+[SuppressUnmanagedCodeSecurityAttribute]
+internal static class UnsafeNativeMethods
+{
+    [DllImport("user32.dll", CharSet = CharSet.Auto, ExactSpelling = true)]
+    internal static extern int ShowCursor([MarshalAs(UnmanagedType.Bool)]bool bShow);
+}
+</pre>
+
+
+
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182161.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182161.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotHideBaseClassMethods">
+    <configKey>CA1061</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1061: Do not hide base class methods]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A derived type declares a method with the same name and with the same number of parameters as one of its base methods; one or more of the parameters is a base type of the corresponding parameter in the base method; and any remaining parameters have types that are identical to the corresponding parameters in the base method.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A method in a base type is hidden by an identically named method in a derived type when the parameter signature of the derived method differs only by types that are more weakly derived than the corresponding types in the parameter signature of the base method.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, remove or rename the method, or change the parameter signature so that the method does not hide the base method.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182143.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182143.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ValidateArgumentsOfPublicMethods">
+    <configKey>CA1062</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1062: Validate arguments of public methods]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An externally visible method dereferences one of its reference arguments without verifying whether that argument is <code>null</code> (<code>Nothing</code> in Visual Basic).
+</p>
+<h2>Rule Description</h2>
+<p>
+            All reference arguments that are passed to externally visible methods should be checked against <code>null</code>. If appropriate, throw a <code>ArgumentNullException</code> when the argument is <code>null</code>.
+            If a method can be called from an unknown assembly because it is declared public or protected, you should validate all parameters of the method. If the method is designed to be called only by known assemblies, you should make the method internal and apply the <code>InternalsVisibleToAttribute</code>  attribute to the assembly that contains the method.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, validate each reference argument against <code>null</code>.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+             You can suppress a warning from this rule if you are sure that the dereferenced parameter has been validated by another method call in the function.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182182.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182182.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ImplementIDisposableCorrectly">
+    <configKey>CA1063</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1063: Implement IDisposable correctly]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+
+
+                <code>IDisposable</code>
+               is not implemented correctly. Some reasons for this problem are listed here:
+            <ul>
+              <li>
+                IDisposable is re-implemented in the class.
+              </li>
+              <li>
+                Finalize is re-overridden.
+              </li>
+              <li>
+                Dispose is overridden.
+              </li>
+              <li>
+                Dispose() is not public, sealed, or named Dispose.
+              </li>
+              <li>
+                Dispose(bool) is not protected, virtual, or unsealed.
+              </li>
+              <li>
+                In unsealed types, Dispose() must call Dispose(true).
+              </li>
+              <li>
+                For unsealed types, the Finalize implementation does not call either or both Dispose(bool) or the case class finalizer.
+              </li>
+            </ul>
+            Violation of any one of these patterns will trigger this warning.
+            Every unsealed root IDisposable type must provide its own protected virtual void Dispose(bool) method. Dispose() should call Dipose(true) and Finalize should call Dispose(false). If you are creating an unsealed root IDisposable type, you must define Dispose(bool) and call it. For more information, see <code>Cleaning Up Unmanaged Resources</code> in the Framework Design Guidelines section of the .NET Framework documentation.
+</p>
+<h2>Rule Description</h2>
+<p>
+            All IDisposable types should implement the Dispose pattern correctly.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Examine your code and determine which of the following resolutions will fix this violation.
+            <ul>
+              <li>
+                Remove IDisposable from the list of interfaces that are implemented by {0} and override the base class Dispose implementation instead.
+              </li>
+              <li>
+                Remove the finalizer from type {0}, override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false.
+              </li>
+              <li>
+                Remove {0}, override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true.
+              </li>
+              <li>
+                Ensure that {0} is declared as public and sealed.
+              </li>
+              <li>
+                Rename {0} to 'Dispose' and make sure that it is declared as public and sealed.
+              </li>
+              <li>
+                Make sure that {0} is declared as protected, virtual, and unsealed.
+              </li>
+              <li>
+                Modify {0} so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.
+              </li>
+              <li>
+                Modify {0} so that it calls Dispose(false) and then returns.
+              </li>
+              <li>
+                If you are writing an unsealed root IDisposable class, make sure that the implementation of IDisposable follows the pattern that is described earlier in this section.
+              </li>
+            </ul>
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms244737.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms244737.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ExceptionsShouldBePublic">
+    <configKey>CA1064</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1064: Exceptions should be public]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A non-public exception derives directly from <code>Exception</code>, <code>SystemException</code>, or <code>ApplicationException</code>.
+</p>
+<h2>Rule Description</h2>
+<p>
+            An internal exception is only visible inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from <code>Exception</code>, <code>SystemException</code>, or <code>ApplicationException</code>, the external code will not have sufficient information to know what to do with the exception.
+            But, if the code has a public exception that later is used as the base for a internal exception, it is reasonable to assume the code further out will be able to do something intelligent with the base exception. The public exception will have more information than what is provided by T:System.Exception, T:System.SystemException, or T:System.ApplicationException.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Make the exception public, or derive the internal exception from a public exception that is not <code>Exception</code>, <code>SystemException</code>, or <code>ApplicationException</code>.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Suppress a message from this rule if you are sure in all cases that the private exception will be caught within its own internal scope.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb264484.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb264484.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotRaiseExceptionsInUnexpectedLocations">
+    <configKey>CA1065</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1065: Do not raise exceptions in unexpected locations]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method that is not expected to throw exceptions throws an exception.
+</p>
+<h2>Rule Description</h2>
+
+<h3>Property Get Methods</h3>
+<p>
+                Properties are basically smart fields. Therefore, they should behave like a field as much as possible. Fields do not throw exceptions and neither should properties. If you have a property that throws an exception, consider making it a method.
+                The following exceptions are allowed to be thrown from a property get method:
+                <ul>
+                  <li>
+
+
+                        <code>System.InvalidOperationException</code>
+                       and all derivatives (including <code>System.ObjectDisposedException</code>)
+                  </li>
+                  <li>
+
+
+                        <code>System.NotSupportedException</code>
+                       and all derivatives
+                  </li>
+                  <li>
+
+
+                        <code>System.ArgumentException</code>
+                       (only from indexed get)
+                  </li>
+                  <li>
+
+
+                        <code>KeyNotFoundException</code>
+                       (only from indexed get)
+                  </li>
+                </ul>
+</p>
+<h3>Event Accessor Methods</h3>
+<p>
+                Event accessors should be simple operations that do not throw exceptions. An event should not throw an exception when you try to add or remove an event handler.
+                The following exceptions are allowed to be thrown from an event accesor:
+                <ul>
+                  <li>
+
+
+                        <code>System.InvalidOperationException</code>
+                       and all derivatives (including <code>System.ObjectDisposedException</code>)
+                  </li>
+                  <li>
+
+
+                        <code>System.NotSupportedException</code>
+                       and all derivatives
+                  </li>
+                  <li>
+
+
+                        <code>ArgumentException</code>
+                       and derivatives
+                  </li>
+                </ul>
+</p>
+<h3>Equals Methods</h3>
+<p>
+                The following Equals methods should not throw exceptions:
+                <ul>
+                  <li>
+
+
+                        <code>Object.Equals</code>
+
+
+                  </li>
+                  <li>
+
+                      M:IEquatable.Equals
+
+                  </li>
+                </ul>
+                An Equals method should return <code>true</code> or <code>false</code> instead of throwing an exception. For example, if Equals is passed two mismatched types it should just return <code>false</code> instead of throwing an <code>ArgumentException</code>.
+</p>
+<h3>GetHashCode Methods</h3>
+<p>
+                The following GetHashCode methods should usually not throw exceptions:
+                <ul>
+                  <li>
+
+
+                        <code>GetHashCode</code>
+
+
+                  </li>
+                  <li>
+
+                      M:IEqualityComparer.GetHashCode(T)
+
+                  </li>
+                </ul>
+
+                  GetHashCode should always return a value. Otherwise, you can lose items in the hash table.
+                The versions of GetHashCode that take an argument can throw an <code>ArgumentException</code>. However, Object.GetHashCode should never throw an exception.
+</p>
+<h3>ToString Methods</h3>
+<p>
+                The debugger uses <code>Object.ToString</code> to help display information about objects in string format. Therefore, ToString should not change the state of an object and it should not throw exceptions.
+</p>
+<h3>Static Constructors</h3>
+<p>
+                Throwing exceptions from a static constructor causes the type to be unusable in the current application domain. You should have a very good reason (such as a security issue) for throwing an exception from a static constructor.
+</p>
+<h3>Finalizers</h3>
+<p>
+                Throwing an exception from a finalizer causes the CLR to fail fast, which tears down the process. Therefore, throwing exceptions in a finalizer should always be avoided.
+</p>
+<h3>Dispose Methods</h3>
+<p>
+                A <code>IDisposable.Dispose</code> method should not throw an exception. Dispose is often called as part of the clean up logic in a <code>finally</code> clause. Therefore, explicitly throwing an exception from Dispose forces the user to add exception handling inside the <code>finally</code> clause.
+                The Dispose(false) code path should never throw exceptions, because this is almost always called from a finalizer.
+</p>
+<h3>Equality Operators (==, !=)</h3>
+<p>
+                Like Equals methods, equality operators should return either <code>true</code> or <code>false</code> and should not throw exceptions.
+</p>
+<h3>Implicit Cast Operators</h3>
+<p>
+                Because the user is often unaware that an implicit cast operator has been called, an exception thrown by the implicit cast operator is completely unexpected. Therefore, no exceptions should be thrown from implicit cast operators.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            For property getters, either change the logic so that it no longer has to throw an exception, or change the property into a method.
+            For all other method types listed previously, change the logic so that it no longer must throw an exception.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if the violation was caused by an exception declaration instead of a thrown exception.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                CA2219: Do not raise exceptions in exception clauses
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb386039.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb386039.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="SpecifyMessageBoxOptions">
+    <configKey>CA1300</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1300: Specify MessageBoxOptions]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method calls an overload of the <code>MessageBox.Show</code> method that does not take a <code>System.Windows.Forms.MessageBoxOptions</code> argument.
+</p>
+<h2>Rule Description</h2>
+<p>
+            To display a message box correctly for cultures that use a right-to-left reading order, the <code>RightAlign</code> and <code>RtlReading</code> members of the <code>MessageBoxOptions</code> enumeration must be passed to the <code>Show</code> method. Examine the <code>Control.RightToLeft</code> property of the containing control to determine whether to use a right-to-left reading order.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, call an overload of the <code>Show</code> method that takes a <code>MessageBoxOptions</code> argument.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule when the code library will not be localized for a culture that uses a right-to-left reading order.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182191.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182191.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AvoidDuplicateAccelerators">
+    <configKey>CA1301</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1301: Avoid duplicate accelerators]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type extends <code>System.Windows.Forms.Control</code> and contains two or more top level controls that have identical access keys that are stored in a resource file.
+</p>
+<h2>Rule Description</h2>
+<p>
+            An access key, also known as an accelerator, enables keyboard access to a control by using the ALT key. When multiple controls have duplicate access keys, the behavior of the access key is not well defined. The user might not be able to access the intended control by using the access key and a control other than the one that is intended might be enabled.
+            The current implementation of this rule ignores menu items. However, menu items in the same submenu should not have identical access keys.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, define unique access keys for all controls.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182185.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182185.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotHardcodeLocaleSpecificStrings">
+    <configKey>CA1302</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1302: Do not hardcode locale specific strings]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method uses a string literal that represents part of the path of certain system folders.
+</p>
+<h2>Rule Description</h2>
+<p>
+            The <code>System.Environment.SpecialFolder</code> enumeration contains members that refer to special system folders. The locations of these folders can have different values on different operating systems, the user can change some of the locations, and the locations are localized. An example of a special folder is the System folder, which is "C:\WINDOWS\system32" on Windows XP but "C:\WINNT\system32" on Windows 2000. The <code>Environment.GetFolderPath</code> method returns the locations that are associated with the <code>Environment.SpecialFolder</code> enumeration. The locations that are returned by <code>GetFolderPath</code> are localized and appropriate for the currently running computer.
+            This rule tokenizes the folder paths that are retrieved by using the <code>GetFolderPath</code> method into separate directory levels. Each string literal is compared to the tokens. If a match is found, it is assumed that the method is building a string that refers to the system location that is associated with the token. For portability and localizability, use the <code>GetFolderPath</code> method to retrieve the locations of the special system folders instead of using string literals.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, retrieve the location by using the <code>GetFolderPath</code> method.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if the string literal is not used to refer to one of the system locations that is associated with the <code>Environment.SpecialFolder</code> enumeration.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:DoNotPassLiteralsAsLocalizedParameters}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182186.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182186.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotPassLiteralsAsLocalizedParameters">
+    <configKey>CA1303</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1303: Do not pass literals as localized parameters]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method passes a string literal as a parameter to a constructor or method in the .NET Framework class library and that string should be localizable.
+            This warning is raised when a literal string is passed as a value to a parameter or property and one or more of the following cases is true:
+            <ul>
+              <li>
+                The <code>LocalizableAttribute</code> attribute of the parameter or property is set to true.
+              </li>
+              <li>
+                The parameter or property name contains "Text", "Message", or "Caption".
+              </li>
+              <li>
+                The name of the string parameter that is passed to a Console.Write or Console.WriteLine method is either "value" or "format".
+              </li>
+            </ul>
+</p>
+<h2>Rule Description</h2>
+<p>
+            String literals that are embedded in source code are difficult to localize.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, replace the string literal with a string retrieved through an instance of the <code>ResourceManager</code> class.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if the code library will not be localized, or if the string is not exposed to the end user or a developer using the code library.
+            Users can eliminate noise against methods which should not be passed localized strings by either renaming the parameter or property named, or by marking these items as conditional.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182187.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182187.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="SpecifyCultureInfo">
+    <configKey>CA1304</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1304: Specify CultureInfo]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method or constructor calls a member that has an overload that accepts a <code>System.Globalization.CultureInfo</code> parameter, and the method or constructor does not call the overload that takes the <code>CultureInfo</code> parameter. This rule ignores calls to the following methods:
+            <ul>
+              <li>
+
+
+                    <code>Activator.CreateInstance</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>ResourceManager.GetObject</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>ResourceManager.GetString</code>
+
+
+              </li>
+            </ul>
+</p>
+<h2>Rule Description</h2>
+<p>
+            When a <code>CultureInfo</code> or <code>System.IFormatProvider</code> object is not supplied, the default value that is supplied by the overloaded member might not have the effect that you want in all locales. Also, .NET Framework members choose default culture and formatting based on assumptions that might not be correct for your code. To ensure the code works as expected for your scenarios, you should supply culture-specific information according to the following guidelines:
+            <ul>
+              <li>
+                If the value will be displayed to the user, use the current culture. See <code>CultureInfo.CurrentCulture</code>.
+              </li>
+              <li>
+                If the value will be stored and accessed by software, that is, persisted to a file or database, use the invariant culture. See <code>CultureInfo.InvariantCulture</code>.
+              </li>
+              <li>
+                If you do not know the destination of the value, have the data consumer or provider specify the culture.
+              </li>
+            </ul>
+            Note that <code>CultureInfo.CurrentUICulture</code> is used only to retrieve localized resources by using an instance of the <code>System.Resources.ResourceManager</code> class.
+            Even if the default behavior of the overloaded member is appropriate for your needs, it is better to explicitly call the culture-specific overload so that your code is self-documenting and more easily maintained.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, use the overload that takes a <code>CultureInfo</code> or <code>IFormatProvider</code> and specify the argument according to the guidelines that were listed earlier.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule when it is certain that the default culture/format provider is the correct choice, and where code maintainability is not an important development priority.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:SpecifyIFormatProvider}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182189.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182189.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="SpecifyIFormatProvider">
+    <configKey>CA1305</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1305: Specify IFormatProvider]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method or constructor calls one or more members that have overloads that accept a <code>System.IFormatProvider</code> parameter, and the method or constructor does not call the overload that takes the <code>IFormatProvider</code> parameter. This rule ignores calls to .NET Framework methods that are documented as ignoring the <code>IFormatProvider</code> parameter and additionally the following methods:
+            <ul>
+              <li>
+
+
+                    <code>Activator.CreateInstance</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>ResourceManager.GetObject</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>ResourceManager.GetString</code>
+
+
+              </li>
+            </ul>
+</p>
+<h2>Rule Description</h2>
+<p>
+            When a <code>System.Globalization.CultureInfo</code> or <code>IFormatProvider</code> object is not supplied, the default value that is supplied by the overloaded member might not have the effect that you want in all locales. Also, .NET Framework members choose default culture and formatting based on assumptions that might not be correct for your code. To make sure that the code works as expected for your scenarios, you should supply culture-specific information according to the following guidelines:
+            <ul>
+              <li>
+                If the value will be displayed to the user, use the current culture. See <code>CultureInfo.CurrentCulture</code>.
+              </li>
+              <li>
+                If the value will be stored and accessed by software (persisted to a file or database), use the invariant culture. See <code>CultureInfo.InvariantCulture</code>.
+              </li>
+              <li>
+                If you do not know the destination of the value, have the data consumer or provider specify the culture.
+              </li>
+            </ul>
+            Note that <code>CultureInfo.CurrentUICulture</code> is used only to retrieve localized resources by using an instance of the <code>System.Resources.ResourceManager</code> class.
+            Even if the default behavior of the overloaded member is appropriate for your needs, it is better to explicitly call the culture-specific overload so that your code is self-documenting and more easily maintained.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, use the overload that takes a <code>CultureInfo</code> or <code>IFormatProvider</code> and specify the argument according to the guidelines that were listed earlier.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule when it is certain that the default culture/format provider is the correct choice and where code maintainability is not an important development priority.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:SpecifyCultureInfo}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182190.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182190.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="SetLocaleForDataTypes">
+    <configKey>CA1306</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1306: Set locale for data types]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method or constructor created one or more <code>System.Data.DataTable</code> or <code>System.Data.DataSet</code> instances and did not explicitly set the locale property (<code>DataTable.Locale</code> or <code>DataSet.Locale</code>).
+</p>
+<h2>Rule Description</h2>
+<p>
+            The locale determines culture-specific presentation elements for data, such as formatting used for numeric values, currency symbols, and sort order. When you create a <code>DataTable</code> or <code>DataSet</code>, you should set the locale explicitly. By default, the locale for these types is the current culture. For data that is stored in a database or file and is shared globally, the locale should ordinarily be set to the invariant culture (<code>CultureInfo.InvariantCulture</code>). When data is shared across cultures, using the default locale can cause the contents of the <code>DataTable</code> or <code>DataSet</code> to be presented or interpreted incorrectly.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, explicitly set the locale for the <code>DataTable</code> or <code>DataSet</code>.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule when the library or application is for a limited local audience, the data is not shared, or the default setting yields the desired behavior in all supported scenarios.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182188.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182188.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="SpecifyStringComparison">
+    <configKey>CA1307</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1307: Specify StringComparison]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A string comparison operation uses a method overload that does not set a <code>StringComparison</code> parameter.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Many string operations, most important the <code>Compare</code> and <code>Equals</code> methods, provide an overload that accepts a <code>StringComparison</code> enumeration value as a parameter.
+            Whenever an overload exists that takes a <code>StringComparison</code> parameter, it should be used instead of an overload that does not take this parameter. By explicitly setting this parameter, your code is often made clearer and easier to maintain.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change string comparison methods to overloads that accept the <code>StringComparison</code> enumeration as a parameter. For example: change String.Compare(str1, str2) to String.Compare(str1, str2, StringComparison.Ordinal).
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule when the library or application is intended for a limited local audience and will therefore not be localized.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb386080.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb386080.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="NormalizeStringsToUppercase">
+    <configKey>CA1308</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1308: Normalize strings to uppercase]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An operation normalizes a string to lowercase.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Strings should be normalized to uppercase. A small group of characters, when they are converted to lowercase, cannot make a round trip. To make a round trip means to convert the characters from one locale to another locale that represents character data differently, and then to accurately retrieve the original characters from the converted characters.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Change operations that convert strings to lowercase so that the strings are converted to uppercase instead. For example, change String.ToLower(CultureInfo.InvariantCulture) to String.ToUpper(CultureInfo.InvariantCulture).
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning message when you are not making security decision based on the result (for example, when you are displaying it in the UI).
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb386042.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb386042.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="UseOrdinalStringComparison">
+    <configKey>CA1309</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1309: Use ordinal StringComparison]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A string comparison operation that is nonlinguistic does not set the <code>StringComparison</code> parameter to either Ordinal or OrdinalIgnoreCase.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Many string operations, most important the String.Compare and String.Equals methods, now provide an overload that accepts a StringComparision enumeration value as a parameter.
+            When you specify either StringComparison.Ordinal or StringComparison.OrdinalIgnoreCase, the string comparison will be nonlinguistic. That is, the features that are specific to the natural language are ignored when comparison decisions are made. This means the decisions are based on simple byte comparisons and ignore casing or equivalence tables that are parameterized by culture. As a result, by explicitly setting the parameter to either the StringComparison.Ordinal or StringComparison.OrdinalIgnoreCase, your code often gains speed, increases correctness, and becomes more reliable.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the string comparison method to an overload that accepts the <code>System.StringComparison</code> enumeration as a parameter, and specify either Ordinal or OrdinalIgnoreCase. For example, change String.Compare(str1, str2) to String.Compare(str1, str2, StringComparison.Ordinal).
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule when the library or application is intended for a limited local audience or when the semantics of the current culture should be used.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb385972.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb385972.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="PInvokeEntryPointsShouldExist">
+    <configKey>CA1400</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1400: P/Invoke entry points should exist]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected method is marked with the <code>System.Runtime.InteropServices.DllImportAttribute</code>. Either the unmanaged library could not be located or the method could not be matched to a function in the library. If the rule cannot find the method name exactly as it is specified, it looks for ANSI or wide-character versions of the method by suffixing the method name with 'A' or 'W'. If no match is found, the rule attempts to locate a function by using the __stdcall name format (_MyMethod@12, where 12 represents the length of the arguments). If no match is found, and the method name starts with '#', the rule searches for the function as an ordinal reference instead of a name reference.
+</p>
+<h2>Rule Description</h2>
+<p>
+            No compile-time check is available to make sure that methods that are marked with <code>DllImportAttribute</code> are located in the referenced unmanaged DLL. If no function that has the specified name is  in the library, or the arguments to the method do not match the function arguments, the common language runtime throws an exception.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, correct the method that has the <code>DllImportAttribute</code> attribute. Make sure that the unmanaged library exists and is in the same directory as the assembly that contains the method. If the library is present and correctly referenced, verify that the method name, return type, and argument signature match the library function.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule when the unmanaged library is in the same directory as the managed assembly that references it. It might be safe to suppress a warning from this rule in the case where the unmanaged library could not be located.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182208.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182208.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="PInvokesShouldNotBeVisible">
+    <configKey>CA1401</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1401: P/Invokes should not be visible]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected method in a public type has the <code>System.Runtime.InteropServices.DllImportAttribute</code> attribute (also implemented by the <code>Declare</code> keyword in Visual Basic).
+</p>
+<h2>Rule Description</h2>
+<p>
+            Methods that are marked with the <code>DllImportAttribute</code> attribute (or methods that are defined by using the <code>Declare</code> keyword in Visual Basic) use Platform Invocation Services to access unmanaged code. Such methods should not be exposed. By keeping these methods private or internal, you make sure that your library cannot be used to breach security by allowing callers access to unmanaged APIs that they could not call otherwise.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the access level of the method.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182209.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182209.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AvoidOverloadsInComVisibleInterfaces">
+    <configKey>CA1402</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1402: Avoid overloads in COM visible interfaces]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A Component Object Model (COM) visible interface declares overloaded methods.
+</p>
+<h2>Rule Description</h2>
+<p>
+            When overloaded methods are exposed to COM clients, only the first method overload retains its name. Subsequent overloads are uniquely renamed by appending to the name an underscore character '_' and an integer that corresponds to the order of declaration of the overload. For example, consider the following methods.
+
+
+
+
+
+
+
+
+
+            <pre>
+   void SomeMethod(int valueOne);
+   void SomeMethod(int valueOne, int valueTwo, int valueThree);
+   void SomeMethod(int valueOne, int valueTwo);
+</pre>
+
+
+
+
+These methods are exposed to COM clients as the following.
+
+
+
+
+
+
+
+
+
+            <pre>
+   void SomeMethod(int valueOne);
+   void SomeMethod_2(int valueOne, int valueTwo, int valueThree);
+   void SomeMethod_3(int valueOne, int valueTwo);
+</pre>
+
+
+
+
+Visual Basic 6 COM clients cannot implement interface methods by using an underscore in the name.
+
+
+
+
+
+
+                How to Fix Violations
+
+
+
+
+
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:AvoidNonpublicFieldsInComVisibleValueTypes}<br/>
+
+
+
+
+                {rule:fxcop:AvoidStaticMembersInComVisibleTypes}<br/>
+
+
+
+
+                {rule:fxcop:MarkAssembliesWithComVisible}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182197.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182197.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AutoLayoutTypesShouldNotBeComVisible">
+    <configKey>CA1403</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1403: Auto layout types should not be COM visible]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A Component Object Model (COM) visible value type is marked with the <code>System.Runtime.InteropServices.StructLayoutAttribute</code> attribute set to <code>LayoutKind.Auto</code>.
+</p>
+<h2>Rule Description</h2>
+<p>
+
+
+                <code>Auto</code>
+               layout types are managed by the common language runtime. The layout of these types can change between versions of the .NET Framework, which will break COM clients that expect a specific layout. Note that if the <code>StructLayoutAttribute</code> attribute is not specified, the C#, Visual Basic, and C++ compilers specify the <code>Sequential</code> layout for value types.
+            Unless marked otherwise, all public nongeneric types are visible to COM; all nonpublic and generic types are invisible to COM. However, to reduce false positives, this rule requires the COM visibility of the type to be explicitly stated; the containing assembly must be marked with the <code>System.Runtime.InteropServices.ComVisibleAttribute</code> set to <code>false</code> and the type must be marked with the <code>ComVisibleAttribute</code> set to <code>true</code>.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the value of the <code>StructLayoutAttribute</code> attribute to <code>Explicit</code> or <code>Sequential</code>, or make the type invisible to COM.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:DoNotUseAutoDualClassInterfaceType}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182194.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182194.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="CallGetLastErrorImmediatelyAfterPInvoke">
+    <configKey>CA1404</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1404: Call GetLastError immediately after P/Invoke]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A call is made to the Marshal.GetLastWin32Error method or the equivalent Win32 <code>GetLastError</code> function, and the call that comes immediately before is not to a platform invoke method.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A platform invoke method accesses unmanaged code and is defined by using the <code>Declare</code> keyword in Visual Basic or the <code>System.Runtime.InteropServices.DllImportAttribute</code> attribute. Generally, upon failure, unmanaged functions call the Win32 <code>SetLastError</code> function to set an error code that is associated with the failure. The caller of the failed function calls the Win32 <code>GetLastError</code> function to retrieve the error code and determine the cause of the failure. The error code is maintained on a per-thread basis and is overwritten by the next call to <code>SetLastError</code>. After a call to a failed platform invoke method, managed code can retrieve the error code by calling the GetLastWin32Error method. Because the error code can be overwritten by internal calls from other managed class library methods, the <code>GetLastError</code> or GetLastWin32Error method should be called immediately after the platform invoke method call.
+            The rule ignores calls to the following managed members when they occur between the call to the platform invoke method and the call to GetLastWin32Error. These members do not change the error code and are useful for determining the success of some platform invoke method calls.
+            <ul>
+              <li>
+
+
+                    <code>IntPtr.Zero</code>
+
+
+              </li>
+              <li>
+
+
+                    IntPtr.Equality
+
+
+              </li>
+              <li>
+
+
+                    IntPtr.Inequality
+
+
+              </li>
+              <li>
+
+
+                    <code>SafeHandle.IsInvalid</code>
+
+
+              </li>
+            </ul>
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, move the call to GetLastWin32Error so that it immediately follows the call to the platform invoke method.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if the code between the platform invoke method call and the GetLastWin32Error method call cannot explicitly or implicitly cause the error code to change.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:MovePInvokesToNativeMethodsClass}<br/>
+
+
+
+
+                {rule:fxcop:PInvokeEntryPointsShouldExist}<br/>
+
+
+
+
+                {rule:fxcop:PInvokesShouldNotBeVisible}<br/>
+
+
+
+
+                {rule:fxcop:SpecifyMarshalingForPInvokeStringArguments}<br/>
+
+
+
+
+                {rule:fxcop:UseManagedEquivalentsOfWin32Api}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182199.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182199.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ComVisibleTypeBaseTypesShouldBeComVisible">
+    <configKey>CA1405</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1405: COM visible type base types should be COM visible]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A Component Object Model (COM) visible type derives from a type that is not COM visible.
+</p>
+<h2>Rule Description</h2>
+<p>
+            When a COM visible type adds members in a new version, it must abide by strict guidelines to avoid breaking COM clients that bind to the current version. A type that is invisible to COM presumes it does not have to follow these COM versioning rules when it adds new members. However, if a COM visible type derives from the COM invisible type and exposes a class interface of <code>ClassInterfaceType.AutoDual</code> or <code>AutoDispatch</code> (the default), all public members of the base type (unless they are specifically marked as COM invisible, which would be redundant) are exposed to COM. If the base type adds new members in a subsequent version, any COM clients that bind to the class interface of the derived type might break. COM visible types should derive only from COM visible types to reduce the chance of breaking COM clients.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, make the base types COM visible or the derived type COM invisible.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182202.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182202.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AvoidInt64ArgumentsForVB6Clients">
+    <configKey>CA1406</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1406: Avoid Int64 arguments for Visual Basic 6 clients]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type that is specifically marked as visible to Component Object Model (COM) declares a member that takes a System.Int64 argument.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Visual Basic 6 COM clients cannot access 64-bit integers.
+            By default, the following are visible to COM: assemblies, public types, public instance members in public types, and all members of public value types. However, to reduce false positives, this rule requires the COM visibility of the type to be explicitly stated; the containing assembly must be marked with the <code>System.Runtime.InteropServices.ComVisibleAttribute</code> set to <code>false</code> and the type must be marked with the <code>ComVisibleAttribute</code> set to <code>true</code>.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule for a parameter whose value can always be expressed as a 32-bit integral, change the parameter type to System.Int32. If the value of the parameter might be larger than can be expressed as a 32-bit integral, change the parameter type to <code>System.Decimal</code>. Note that both <code>System.Single</code> and <code>System.Double</code> lose precision at the upper ranges of the Int64 data type. If the member is not meant to be visible to COM, mark it with the <code>ComVisibleAttribute</code> set to <code>false</code>.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if it is certain that Visual Basic 6 COM clients will not access the type.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:AvoidNonpublicFieldsInComVisibleValueTypes}<br/>
+
+
+
+
+                {rule:fxcop:AvoidStaticMembersInComVisibleTypes}<br/>
+
+
+
+
+                {rule:fxcop:MarkAssembliesWithComVisible}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182195.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182195.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AvoidStaticMembersInComVisibleTypes">
+    <configKey>CA1407</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1407: Avoid static members in COM visible types]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type that is specifically marked as visible to Component Object Model (COM) contains a <code>public</code> <code>static</code> method.
+</p>
+<h2>Rule Description</h2>
+<p>
+            COM does not support <code>static</code> methods.
+            This rule ignores property and event accessors, operator overloading methods, or methods that are marked by using either the <code>System.Runtime.InteropServices.ComRegisterFunctionAttribute</code> attribute or the <code>System.Runtime.InteropServices.ComUnregisterFunctionAttribute</code> attribute.
+            By default, the following are visible to COM: assemblies, public types, public instance members in public types, and all members of public value types.
+            For this rule to occur, an assembly-level <code>ComVisibleAttribute</code> must be set to <code>false</code> and the class- <code>ComVisibleAttribute</code> must be set to <code>true</code>, as the following code shows.
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+using System.Runtime.InteropServices;
+
+[assembly: ComVisible(false)]
+namespace Samples
+{
+    [ComVisible(true)]
+    public class MyClass
+    {
+        public static void DoSomething()
+        {
+        }
+    }
+}
+</pre>
+
+
+
+
+
+
+
+
+
+
+
+                How to Fix Violations
+
+
+
+
+
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if a COM client does not require access to the functionality that is provided by the <code>static</code> method.
+</p>
+<h2>Example Violation</h2>
+
+<h3>Description</h3>
+<p>
+                The following example shows a <code>static</code> method that violates this rule.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+using System.Runtime.InteropServices;
+using System.Collections.ObjectModel;
+
+[assembly: ComVisible(false)]
+
+namespace Samples
+{
+    [ComVisible(true)]
+    public class Book
+    {
+        private Collection&lt;string&gt; _Pages = new Collection&lt;string&gt;();
+
+        public Book()
+        {
+        }
+
+        public Collection&lt;string&gt; Pages
+        {
+            get { return _Pages; }
+        }
+
+        // Violates this rule         
+        public static Book FromPages(string[] pages)
+        {
+            if (pages == null)
+                throw new ArgumentNullException("pages");
+
+            Book book = new Book();
+
+            foreach (string page in pages)
+            {
+                book.Pages.Add(page);
+            }             return book;
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h3>Comments</h3>
+<p>
+                In this example, the Book.FromPages method cannot be called from COM.
+</p>
+<h2>Example Fix</h2>
+
+<h3>Description</h3>
+<p>
+                To fix the violation in the previous example, you could change the method to an instance method, but that does not make sense in this instance. A better solution is to explicitly apply ComVisible(false) to the method to make it clear to other developers that the method cannot be seen from COM.
+                The following example applies <code>ComRegisterFunctionAttribute</code> to the method.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+using System.Runtime.InteropServices;
+using System.Collections.ObjectModel;
+
+[assembly: ComVisible(false)]
+
+namespace Samples
+{
+    [ComVisible(true)]
+    public class Book
+    {
+        private Collection&lt;string&gt; _Pages = new Collection&lt;string&gt;();
+
+        public Book()
+        {
+        }
+
+        public Collection&lt;string&gt; Pages
+        {
+            get { return _Pages; }
+        }
+
+        [ComVisible(false)]
+        public static Book FromPages(string[] pages)
+        {
+            if (pages == null)
+                throw new ArgumentNullException("pages");
+
+            Book book = new Book();
+
+            foreach (string page in pages)
+            {
+                book.Pages.Add(page);
+            }
+
+            return book;
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:MarkAssembliesWithComVisible}<br/>
+
+
+
+
+                {rule:fxcop:AvoidInt64ArgumentsForVB6Clients}<br/>
+
+
+
+
+                {rule:fxcop:AvoidNonpublicFieldsInComVisibleValueTypes}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182198.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182198.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotUseAutoDualClassInterfaceType">
+    <configKey>CA1408</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1408: Do not use AutoDual ClassInterfaceType]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A Component Object Model (COM) visible type is marked with the <code>ClassInterfaceAttribute</code> attribute set to the <code>AutoDual</code> value of <code>ClassInterfaceType</code>.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Types that use a dual interface enable clients to bind to a specific interface layout. Any changes in a future version to the layout of the type or any base types will break COM clients that bind to the interface. By default, if the <code>ClassInterfaceAttribute</code> attribute is not specified, a dispatch-only interface is used.
+            Unless marked otherwise, all public nongeneric types are visible to COM; all nonpublic and generic types are invisible to COM.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the value of the <code>ClassInterfaceAttribute</code> attribute to the <code>None</code> value of <code>ClassInterfaceType</code> and explicitly define the interface.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule unless it is certain that the layout of the type and its base types will not change in a future version.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:AutoLayoutTypesShouldNotBeComVisible}<br/>
+
+
+
+
+                {rule:fxcop:MarkComSourceInterfacesAsIDispatch}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182205.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182205.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ComVisibleTypesShouldBeCreatable">
+    <configKey>CA1409</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1409: Com visible types should be creatable]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A reference type that is specifically marked as visible to Component Object Model (COM) contains a public parameterized constructor but does not contain a public default (parameterless) constructor.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A type without a public default constructor cannot be created by COM clients. However, the type can still be accessed by COM clients if another means is available to create the type and pass it to the client (for example, through the return value of a method call).
+            The rule ignores types that are derived from <code>System.Delegate</code>.
+            By default, the following are visible to COM: assemblies, public types, public instance members in public types, and all members of public value types.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, add a public default constructor or remove the <code>System.Runtime.InteropServices.ComVisibleAttribute</code> from the type.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if other ways are provided to create and pass the object to the COM client.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:MarkAssembliesWithComVisible}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182203.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182203.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ComRegistrationMethodsShouldBeMatched">
+    <configKey>CA1410</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1410: COM registration methods should be matched]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type declares a method that is marked with the <code>System.Runtime.InteropServices.ComRegisterFunctionAttribute</code> attribute but does not declare a method that is marked with the <code>System.Runtime.InteropServices.ComUnregisterFunctionAttribute</code> attribute, or vice versa.
+</p>
+<h2>Rule Description</h2>
+<p>
+            For Component Object Model (COM) clients to create a .NET Framework type, the type must first be registered. If it is available, a method that is marked with the <code>ComRegisterFunctionAttribute</code> attribute is called during the registration process to run user-specified code. A corresponding method that is marked with the <code>ComUnregisterFunctionAttribute</code> attribute is called during the unregistration process to reverse the operations of the registration method.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, add the corresponding registration or unregistration method.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:ComRegistrationMethodsShouldNotBeVisible}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182200.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182200.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ComRegistrationMethodsShouldNotBeVisible">
+    <configKey>CA1411</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1411: COM registration methods should not be visible]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method that is marked with the <code>System.Runtime.InteropServices.ComRegisterFunctionAttribute</code> or the <code>System.Runtime.InteropServices.ComUnregisterFunctionAttribute</code> attribute is externally visible.
+</p>
+<h2>Rule Description</h2>
+<p>
+            When an assembly is registered with Component Object Model (COM), entries are added to the registry for each COM-visible type in the assembly. Methods that are marked with the <code>ComRegisterFunctionAttribute</code> and <code>ComUnregisterFunctionAttribute</code> attributes are called during the registration and unregistration processes, respectively, to run user code that is specific to the registration/unregistration of these types. This code should not be called outside these processes.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the accessibility of the method to <code>private</code> or <code>internal</code> (<code>Friend</code> in Visual Basic).
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:ComRegistrationMethodsShouldBeMatched}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182201.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182201.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="MarkComSourceInterfacesAsIDispatch">
+    <configKey>CA1412</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1412: Mark ComSource Interfaces as IDispatch]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type is marked with the <code>ComSourceInterfacesAttribute</code> attribute and at least one specified interface is not marked with the <code>InterfaceTypeAttribute</code> attribute set to the <code>InterfaceIsDispatch</code> value.
+</p>
+<h2>Rule Description</h2>
+<p>
+
+
+                <code>ComSourceInterfacesAttribute</code>
+               is used to identify the event interfaces that a class exposes to Component Object Model (COM) clients. These interfaces must be exposed as <code>InterfaceIsIDispatch</code> to enable Visual Basic 6 COM clients to receive event notifications. By default, if an interface is not marked with the <code>InterfaceTypeAttribute</code> attribute, it is exposed as a dual interface.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, add or modify the <code>InterfaceTypeAttribute</code> attribute so that its value is set to InterfaceIsIDispatch for all interfaces that are specified with the <code>ComSourceInterfacesAttribute</code> attribute.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:DoNotUseAutoDualClassInterfaceType}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182207.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182207.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AvoidNonpublicFieldsInComVisibleValueTypes">
+    <configKey>CA1413</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1413: Avoid non-public fields in COM visible value types]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A value type that is specifically marked as visible to Component Object Model (COM) declares a nonpublic instance field.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Nonpublic instance fields of COM-visible value types are visible to COM clients. Review the content of the field for information that should not be exposed, or that will have an unintended design or security effect.
+            By default, all public value types are visible to COM. However, to reduce false positives, this rule requires the COM visibility of the type to be explicitly stated. The containing assembly must be marked with the <code>System.Runtime.InteropServices.ComVisibleAttribute</code> set to <code>false</code> and the type must be marked with the <code>ComVisibleAttribute</code> set to <code>true</code>.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule and keep the field hidden, change the value type to a reference type or remove the <code>ComVisibleAttribute</code> attribute from the type.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if public exposure of the field is acceptable.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:AvoidStaticMembersInComVisibleTypes}<br/>
+
+
+
+
+                {rule:fxcop:MarkAssembliesWithComVisible}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182196.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182196.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="MarkBooleanPInvokeArgumentsWithMarshalAs">
+    <configKey>CA1414</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1414: Mark boolean P/Invoke arguments with MarshalAs]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A platform invoke method declaration includes a <code>System.Boolean</code> parameter or return value but the <code>System.Runtime.InteropServices.MarshalAsAttribute</code> attribute is not applied to the parameter or return value.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A platform invoke method accesses unmanaged code and is defined by using the <code>Declare</code> keyword in Visual Basic or the <code>System.Runtime.InteropServices.DllImportAttribute</code>. <code>MarshalAsAttribute</code> specifies the marshaling behavior that is used to convert data types between managed and unmanaged code. Many simple data types, such as <code>System.Byte</code> and System.Int32, have a single representation in unmanaged code and do not require specification of their marshaling behavior; the common language runtime automatically supplies the correct behavior.
+            The <code>Boolean</code> data type has multiple representations in unmanaged code. When the <code>MarshalAsAttribute</code> is not specified, the default marshaling behavior for the <code>Boolean</code> data type is <code>UnmanagedType.Bool</code>. This is a 32-bit integer, which is not appropriate in all circumstances. The Boolean representation that is required by the unmanaged method should be determined and matched to the appropriate <code>System.Runtime.InteropServices.UnmanagedType</code>. UnmanagedType.Bool is the Win32 BOOL type, which is always 4 bytes. UnmanagedType.U1 should be used for C++ bool or other 1-byte types. For more information, see Default Marshaling for Boolean Types.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, apply <code>MarshalAsAttribute</code> to the <code>Boolean</code> parameter or return value. Set the value of the attribute to the appropriate <code>UnmanagedType</code>.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule. Even if the default marshaling behavior is appropriate, the code is more easily maintained when the behavior is explicitly specified.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:PInvokeDeclarationsShouldBePortable}<br/>
+
+
+
+
+                {rule:fxcop:SpecifyMarshalingForPInvokeStringArguments}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182206.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182206.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DeclarePInvokesCorrectly">
+    <configKey>CA1415</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1415: Declare P/Invokes correctly]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A platform invoke method is incorrectly declared.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A platform invoke method accesses unmanaged code and is defined by using the <code>Declare</code> keyword in Visual Basic or the <code>System.Runtime.InteropServices.DllImportAttribute</code>. Currently, this rule looks for platform invoke method declarations that target Win32 functions that have a pointer to an OVERLAPPED structure parameter and the corresponding managed parameter is not a pointer to a <code>System.Threading.NativeOverlapped</code> structure.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, correctly declare the platform invoke method.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182204.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182204.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="VariableNamesShouldNotMatchFieldNames">
+    <configKey>CA1500</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1500: Variable names should not match field names]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An instance method declares a parameter or a local variable whose name matches an instance field of the declaring type. To catch local variables that violate the rule, the tested assembly must be built by using debugging information and the associated program database (.pdb) file must be available.
+</p>
+<h2>Rule Description</h2>
+<p>
+            When the name of an instance field matches a parameter or a local variable name, the instance field is accessed by using the <code>this</code> (<code>Me</code> in Visual Basic) keyword when inside the method body. When maintaining code, it is easy to forget this difference and assume that the parameter/local variable refers to the instance field, which leads to errors. This is true especially for lengthy method bodies.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, rename either the parameter/variable or the field.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182216.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182216.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AvoidExcessiveInheritance">
+    <configKey>CA1501</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1501: Avoid excessive inheritance]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type is more than four levels deep in its inheritance hierarchy.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Deeply nested type hierarchies can be difficult to follow, understand, and maintain. This rule limits analysis to hierarchies in the same module.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, derive the type from a base type that is less deep in the inheritance hierarchy or eliminate some of the intermediate base types.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule. However, the code might be more difficult to maintain. Note that, depending on the visibility of base types, resolving violations of this rule might create breaking changes. For example, removing public base types is a breaking change.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182213.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182213.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AvoidExcessiveComplexity">
+    <configKey>CA1502</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1502: Avoid excessive complexity]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method has an excessive cyclomatic complexity.
+</p>
+<h2>Rule Description</h2>
+<p>
+
+              Cyclomatic complexity measures the number of linearly independent paths through the method, which is determined by the number and complexity of conditional branches. A low cyclomatic complexity generally indicates a method that is easy to understand, test, and maintain. The cyclomatic complexity is calculated from a control flow graph of the method and is given as follows:
+            cyclomatic complexity = the number of edges - the number of nodes + 1
+            where a node represents a logic branch point and an edge represents a line between nodes.
+            The rule reports a violation when the cyclomatic complexity is more than 25.
+            You can learn more about code metrics at Measuring Complexity and Maintainability of Managed Code,
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, refactor the method to reduce its cyclomatic complexity.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if the complexity cannot easily be reduced and the method is easy to understand, test, and maintain. In particular, a method that contains a large <code>switch</code> (<code>Select</code> in Visual Basic) statement is a candidate for exclusion. The risk of destabilizing the code base late in the development cycle or introducing an unexpected change in runtime behavior in previously shipped code might outweigh the maintainability benefits of refactoring the code.
+</p>
+<h2>How Cyclomatic Complexity is Calculated</h2>
+<p>
+            The cyclomatic complexity is calculated by adding 1 to the following:
+            <ul>
+              <li>
+                Number of branches (such as <code>if</code>, <code>while</code>, and <code>do</code>)
+              </li>
+              <li>
+                Number of <code>case</code> statements in a <code>switch</code>
+              </li>
+            </ul>
+            The following examples show methods that have varying cyclomatic complexities.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:AvoidExcessiveInheritance}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182212.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182212.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ReviewMisleadingFieldNames">
+    <configKey>CA1504</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1504: Review misleading field names]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The name of an instance field starts with "s_" or the name of a <code>static</code> (<code>Shared</code> in Visual Basic) field starts with "m_".
+</p>
+<h2>Rule Description</h2>
+<p>
+            Field names that start with "s_" are associated with static data by many users. Similarly, field names that start with "m_" are associated with instance (member) data. For more easily maintained code, names should follow generally used conventions.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, rename the field by using the appropriate prefix. Alternatively, make the field agree with the current suffix by adding or removing the <code>static</code> modifier.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb164506.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb164506.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AvoidUnmantainableCode">
+    <configKey>CA1505</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1505: Avoid unmaintainable code]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type or method has a low maintainability index value.
+</p>
+<h2>Rule Description</h2>
+<p>
+            The maintainability index is calculated by using the following metrics: lines of code, program volume, and cyclomatic complexity. Program volume is a measure of the difficulty of understanding of a type or method that is based on the number of operators and operands in the code. Cyclomatic complexity is a measure of the structural complexity of the type or method. You can learn more about code metrics at Measuring Complexity and Maintainability of Managed Code.
+            A low maintainability index indicates that a type or method is probably difficult to maintain and would be a good candidate to redesign.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix this violation, redesign the type or method and try to split it into smaller and more focused types or methods.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Exclude this warning when a type or method is still considered maintainable despite its large size or when the type or method cannot be split.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb386043.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb386043.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AvoidExcessiveClassCoupling">
+    <configKey>CA1506</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1506: Avoid excessive class coupling]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type or method is coupled with many other types.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule measures class coupling by counting the number of unique type references that a type or method contains.
+            Types and methods that have a high degree of class coupling can be difficult to maintain. It is a good practice to have types and methods that exhibit low coupling and high cohesion.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix this violation, try to redesign the type or method to reduce the number of types to which it is coupled.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Exclude this warning when the type or method is still considered maintainable despite its large number of dependencies on other types.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb397994.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb397994.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotUseIdleProcessPriority">
+    <configKey>CA1600</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1600: Do not use idle process priority]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            This rule occurs when processes are set to <code>ProcessPriorityClass.Idle</code>.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Do not set process priority to Idle. Processes that have <code>System.Diagnostics.ProcessPriorityClass.Idle</code> will occupy the CPU when it would otherwise be idle, and will therefore block standby.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Set processes to <code>ProcessPriorityClass.BelowNormal</code>.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            This rule should be suppressed only when Idle process priority is required and mobility considerations can be ignored safely.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182219.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182219.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotUseTimersThatPreventPowerStateChanges">
+    <configKey>CA1601</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1601: Do not use timers that prevent power state changes]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A timer has an interval set to occur more than one time per second.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Do not poll more often than one time per second or use timers that occur more frequently than one time per second. Higher-frequency periodic activity will keep the CPU busy and interfere with power-saving idle timers that turn off the display and hard disks.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Set timer intervals to occur less than one time per second.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            This rule should be suppressed only if firing the timer more than one time per second is required and mobility considerations can safely be ignored.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182230.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182230.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotNameEnumValuesReserved">
+    <configKey>CA1700</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1700: Do not name enum values 'Reserved']]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The name of an enumeration member contains the word "reserved".
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule assumes that an enumeration member that has a name that contains "reserved" is not currently used but is a placeholder to be renamed or removed in a future version. Renaming or removing a member is a breaking change. You should not expect users to ignore a member just because its name contains "reserved", nor can you rely on users to read or abide by documentation. Furthermore, because reserved members appear in object browsers and smart integrated development environments, they can cause confusion about which members are actually being used.
+            Instead of using a reserved member, add a new member to the enumeration in the future version. In most cases the addition of the new member is not a breaking change, as long as the addition does not cause the values of the original members to change.
+
+
+
+            In a limited number of cases the addition of a member is a breaking change even when the original members retain their original values. Primarily, the new member cannot be returned from existing code paths without breaking callers that use a <code>switch</code> (<code>Select</code> in Visual Basic) statement on the return value that encompasses the whole member list and that throw an exception in the default case. A secondary concern is that client code might not handle the change in behavior from reflection methods such as <code>Enum.IsDefined</code>. Accordingly, if the new member has to be returned from existing methods or a known application incompatibility occurs because of poor reflection usage, the only nonbreaking solution is to:
+
+              <li>
+                Add a new enumeration that contains the original and new members.
+              </li>
+              <li>
+                Mark the original enumeration with the <code>System.ObsoleteAttribute</code> attribute.
+              </li>
+
+             Follow the same procedure for any externally visible types or members that expose the original enumeration.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, remove or rename the member.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule for a member that is currently used or for libraries that have previously shipped.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:DoNotMarkEnumsWithFlags}<br/>
+
+
+
+
+                {rule:fxcop:DoNotPrefixEnumValuesWithTypeName}<br/>
+
+
+
+
+                {rule:fxcop:EnumStorageShouldBeInt32}<br/>
+
+
+
+
+                {rule:fxcop:EnumsShouldHaveZeroValue}<br/>
+
+
+
+
+                {rule:fxcop:MarkEnumsWithFlags}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182236.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182236.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ResourceStringCompoundWordsShouldBeCasedCorrectly">
+    <configKey>CA1701</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1701: Resource string compound words should be cased correctly]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A resource string contains a compound word that does not appear to be cased correctly.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Each word in the resource string is split into tokens that are based on the casing. Each contiguous two-token combination is checked by the Microsoft spelling checker library. If recognized, the word produces a violation of the rule. Examples of compound words that cause a violation are "CheckSum" and "MultiPart", which should be cased as "Checksum" and "Multipart", respectively. Due to previous common usage, several exceptions are built into the rule, and several single words are flagged, such as "Toolbar" and "Filename", that should be cased as two distinct words. In this example, "ToolBar" and "FileName" would be flagged.
+            Naming conventions provide a common look for libraries that target the common language runtime. This reduces the learning curve that is required for new software libraries, and increases customer confidence that the library was developed by someone who has expertise in developing managed code.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Change the word so that it is cased correctly.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if both parts of the compound word are recognized by the spelling dictionary and the intent is to use two words.
+            You can also add compound words to a custom dictionary for the spelling checker. Words in the custom dictionary do not cause violations. For more information, see How to: Customize the Code Analysis Dictionary.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                CA1702: Compound words should be cased correctly
+
+
+
+
+                {rule:fxcop:IdentifiersShouldBeCasedCorrectly}<br/>
+
+
+
+
+                {rule:fxcop:IdentifiersShouldDifferByMoreThanCase}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb264481.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb264481.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="CompoundWordsShouldBeCasedCorrectly">
+    <configKey>CA1702</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1702: Compound words should be cased correctly]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The name of an identifier contains multiple words and at least one of the words appears to be a compound word that is not cased correctly.
+</p>
+<h2>Rule Description</h2>
+<p>
+            The name of the identifier is split into words that are based on the casing. Each contiguous two-word combination is checked by the Microsoft spelling checker library. If it is recognized, the identifier produces a violation of the rule. Examples of compound words that cause a violation are "CheckSum" and "MultiPart", which should be cased as "Checksum" and "Multipart", respectively. Due to previous common usage, several exceptions are built into the rule, and several single words are flagged, such as "Toolbar" and "Filename", that should be cased as two distinct words (in this case, "ToolBar" and "FileName").
+            Naming conventions provide a common look for libraries that target the common language runtime. This reduces the learning curve that is required for new software libraries, and increases customer confidence that the library was developed by someone who has expertise in developing managed code.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Change the name so that it is cased correctly.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if both parts of the compound word are recognized by the spelling dictionary and the intent is to use two words.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                CA1701: Resource string compound words should be cased correctly
+
+
+
+
+                {rule:fxcop:IdentifiersShouldBeCasedCorrectly}<br/>
+
+
+
+
+                {rule:fxcop:IdentifiersShouldDifferByMoreThanCase}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb264474.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb264474.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ResourceStringsShouldBeSpelledCorrectly">
+    <configKey>CA1703</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1703: Resource strings should be spelled correctly]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A resource string contains one or more words that are not recognized by the Microsoft spelling checker library.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule parses the resource string into words (tokenizing compound words) and checks the spelling of each word/token. For information about the parsing algorithm, see CA1704: Identifiers should be spelled correctly.
+            By default, the English (en) version of the spelling checker is used.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, use complete words that are correctly spelled or add the words to a custom dictionary. For information about how to use custom dictionaries, see CA1704: Identifiers should be spelled correctly.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule. Correctly spelled words reduce the time that is required to learn new software libraries.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                CA1701: Resource string compound words should be cased correctly
+
+
+
+
+                CA1704: Identifiers should be spelled correctly
+
+
+
+
+                CA2204: Literals should be spelled correctly
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb264483.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb264483.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="IdentifiersShouldBeSpelledCorrectly">
+    <configKey>CA1704</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1704: Identifiers should be spelled correctly]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The name of an identifier contains one or more words that are not recognized by the Microsoft spelling checker library. This rule does not check constructors or special-named members such as get and set property accessors.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule parses the identifier into tokens and checks the spelling of each token. The parsing algorithm performs the following transformations:
+            <ul>
+              <li>
+                Uppercase letters start a new token. For example, MyNameIsJoe tokenizes to "My", "Name", "Is", "Joe".
+              </li>
+              <li>
+                For multiple uppercase letters, the last uppercase letter starts a new token. For example, GUIEditor tokenizes to "GUI", "Editor".
+              </li>
+              <li>
+                Leading and trailing apostrophes are removed. For example, 'sender' tokenizes to "sender".
+              </li>
+              <li>
+                Underscores signify the end of a token and are removed. For example, Hello_world tokenizes to "Hello", "world".
+              </li>
+              <li>
+                Embedded ampersands are removed. For example, for&amp;mat tokenizes to "format".
+              </li>
+            </ul>
+            By default, the English (en) version of the spelling checker is used. No other language dictionaries are currently available.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, correct the spelling of the word or add the word to a custom dictionary that is named CustomDictionary.xml. Place the dictionary in the installation directory of the tool, the project directory, or in the directory that is associated with the tool under the profile of the user (%USERPROFILE%\Application Data\...). To learn how to add the custom dictionary to a project in Visual Studio, see How to: Customize the Code Analysis Dictionary
+            <ul>
+              <li>
+                Add words that should not cause a violation under the Dictionary/Words/Recognized path.
+              </li>
+              <li>
+                Add words that should cause a violation under the Dictionary/Words/Unrecognized path.
+              </li>
+              <li>
+                Add words that should be flagged as obsolete under the Dictionary/Words/Deprecated path. See the related rule topic {rule:fxcop:UsePreferredTerms}for more information.
+              </li>
+              <li>
+                Add exceptions to the acronym casing rules to the Dictionary/Acronyms/CasingExceptions path.
+              </li>
+            </ul>
+            The following is an example of the structure of a custom dictionary file.
+
+
+
+
+
+
+
+
+
+            <pre>
+   &lt;Dictionary&gt;
+      &lt;Words&gt;
+         &lt;Unrecognized&gt;
+            &lt;Word&gt;cb&lt;/Word&gt;
+         &lt;/Unrecognized&gt;
+         &lt;Recognized&gt;
+            &lt;Word&gt;stylesheet&lt;/Word&gt;
+            &lt;Word&gt;GotDotNet&lt;/Word&gt;
+         &lt;/Recognized&gt;
+         &lt;Deprecated&gt;
+            &lt;Term PreferredAlternate="EnterpriseServices"&gt;ComPlus&lt;/Term&gt;
+         &lt;/Deprecated&gt;
+      &lt;/Words&gt;
+      &lt;Acronyms&gt;
+         &lt;CasingExceptions&gt;
+            &lt;Acronym&gt;CJK&lt;/Acronym&gt;
+            &lt;Acronym&gt;Pi&lt;/Acronym&gt;
+         &lt;/CasingExceptions&gt;
+      &lt;/Acronyms&gt;
+   &lt;/Dictionary&gt;
+</pre>
+
+
+
+
+
+
+
+
+
+
+
+                When to Suppress Warnings
+
+
+
+
+
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                CA2204: Literals should be spelled correctly
+
+
+
+
+                CA1703: Resource strings should be spelled correctly
+
+
+
+
+                {rule:fxcop:IdentifiersShouldBeCasedCorrectly}<br/>
+
+
+
+
+                {rule:fxcop:IdentifiersShouldDifferByMoreThanCase}<br/>
+
+
+
+
+                {rule:fxcop:IdentifiersShouldNotContainUnderscores}<br/>
+
+
+
+
+                {rule:fxcop:UsePreferredTerms}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb264492.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb264492.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="IdentifiersShouldNotContainUnderscores">
+    <configKey>CA1707</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1707: Identifiers should not contain underscores]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The name of an identifier contains the underscore (_) character.
+</p>
+<h2>Rule Description</h2>
+<p>
+            By convention, identifier names do not contain the underscore (_) character. The rule checks namespaces, types, members, and parameters.
+            Naming conventions provide a common look for libraries that target the common language runtime. This reduces the learning curve that is required for new software libraries, and increases customer confidence that the library was developed by someone who has expertise in developing managed code.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Remove all underscore characters from the name.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:IdentifiersShouldBeCasedCorrectly}<br/>
+
+
+
+
+                {rule:fxcop:IdentifiersShouldDifferByMoreThanCase}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182245.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182245.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="IdentifiersShouldDifferByMoreThanCase">
+    <configKey>CA1708</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1708: Identifiers should differ by more than case]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The names of two types, members, parameters, or fully qualified namespaces are identical when they are converted to lowercase.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Identifiers for namespaces, types, members, and parameters cannot differ only by case because languages that target the common language runtime are not required to be case-sensitive. For example, Visual Basic is a widely used case-insensitive language.
+            This rule fires on publicly visible members only.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Select a name that is unique when it is compared to other identifiers in a case-insensitive manner.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule. The library might not be usable in all available languages in the .NET Framework.
+</p>
+<h2>Example of a Violation</h2>
+<p>
+            The following example demonstrates a violation of this rule.
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+namespace NamingLibrary
+{
+    public class Class1	// IdentifiersShouldDifferByMoreThanCase
+    {
+        protected string someProperty;
+
+        public string SomeProperty
+        {
+            get { return someProperty; }
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:IdentifiersShouldBeCasedCorrectly}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182242.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182242.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="IdentifiersShouldBeCasedCorrectly">
+    <configKey>CA1709</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1709: Identifiers should be cased correctly]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The name of an identifier is not cased correctly.
+            - or -
+            The name of an identifier contains a two-letter acronym and the second letter is lowercase.
+            - or -
+            The name of an identifier contains an acronym of three or more uppercase letters.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Naming conventions provide a common look for libraries that target the common language runtime. This reduces the learning curve that is required for new software libraries, and increases customer confidence that the library was developed by someone who has expertise in developing managed code.
+            By convention, parameter names use camel casing; namespace, type, and member names use Pascal casing. In a camel-cased name, the first letter is lowercase, and the first letter of any remaining words in the name is in uppercase. Examples of camel-cased names are "packetSniffer", "ioFile", and "fatalErrorCode". In a Pascal-cased name, the first letter is uppercase, and the first letter of any remaining words in the name is in uppercase. Examples of Pascal-cased names are "PacketSniffer", "IOFile", and "FatalErrorCode".
+            This rule splits the name into words based on the casing and checks any two-letter words against a list of common two-letter words, such as "In" or "My". If a match is not found, the word is assumed to be an acronym. In addition, this rule assumes it has found an acronym when the name contains either four uppercase letters in a row or three uppercase letters in a row at the end of the name.
+            By convention, two-letter acronyms use all uppercase letters, and acronyms of three or more characters use Pascal casing. The following examples use this naming convention: 'DB', 'CR', 'Cpa', and 'Ecma'. The following examples violate the convention: 'Io', 'XML', and 'DoD', and for nonparameter names, 'xp' and 'cpl'.
+            'ID' is special-cased to cause a violation of this rule. 'Id' is not an acronym but is an abbreviation for 'identification'.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Change the name so that it is cased correctly.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress this warning if you have your own naming conventions, or if the identifier represents a proper name, for example, the name of a company or a technology.
+            You can also add specific terms, abbreviations, and acronyms that to a code analysis custom dictionary. Terms specified in the custom dictionary will not cause violations of this rule. For more information, see How to: Customize the Code Analysis Dictionary
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:IdentifiersShouldDifferByMoreThanCase}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182240.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182240.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="IdentifiersShouldHaveCorrectSuffix">
+    <configKey>CA1710</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1710: Identifiers should have correct suffix]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An identifier does not have the correct suffix.
+</p>
+<h2>Rule Description</h2>
+<p>
+            By convention, the names of types that extend certain base types or that implement certain interfaces, or types derived from these types, have a suffix that is associated with the base type or interface.
+            Naming conventions provide a common look for libraries that target the common language runtime. This reduces the learning curve that is required for new software libraries, and increases customer confidence that the library was developed by someone who has expertise in developing managed code.
+            The following table lists the base types and interfaces that have associated suffixes.
+
+
+
+
+
+
+
+                    Base type/Interface
+
+
+                    Suffix
+
+
+
+
+
+
+                        <code>System.Attribute</code>
+
+
+
+
+                    Attribute
+
+
+
+
+
+
+                        <code>System.EventArgs</code>
+
+
+
+
+                    EventArgs
+
+
+
+
+
+
+                        <code>System.Exception</code>
+
+
+
+
+                    Exception
+
+
+
+
+
+
+                        <code>System.Collections.ICollection</code>
+
+
+
+
+                    Collection
+
+
+
+
+
+
+                        <code>System.Collections.IDictionary</code>
+
+
+
+
+                    Dictionary
+
+
+
+
+
+
+                        <code>System.Collections.IEnumerable</code>
+
+
+
+
+                    Collection
+
+
+
+
+
+
+                        <code>System.Collections.Queue</code>
+
+
+
+
+                    Collection or Queue
+
+
+
+
+
+
+                        <code>System.Collections.Stack</code>
+
+
+
+
+                    Collection or Stack
+
+
+
+
+
+
+                        <code>System.Collections.Generic.ICollection&lt;T&gt;</code>
+
+
+
+
+                    Collection
+
+
+
+
+
+
+                        System.Collections.Generic.IDictionary&lt;TKey, TValue&gt;
+
+
+
+
+                    Dictionary
+
+
+
+
+
+
+                        <code>System.Data.DataSet</code>
+
+
+
+
+                    DataSet
+
+
+
+
+
+
+                        <code>System.Data.DataTable</code>
+
+
+
+
+                    Collection or DataTable
+
+
+
+
+
+
+                        <code>System.IO.Stream</code>
+
+
+
+
+                    Stream
+
+
+
+
+
+
+                        <code>System.Security.IPermission</code>
+
+
+
+
+                    Permission
+
+
+
+
+
+
+                        <code>System.Security.Policy.IMembershipCondition</code>
+
+
+
+
+                    Condition
+
+
+
+
+                    An event-handler delegate.
+
+
+                    EventHandler
+
+
+
+
+            Types that implement <code>ICollection</code> and are a generalized type of data structure, such as a dictionary, stack, or queue, are allowed names that provide meaningful information about the intended usage of the type.
+            Types that implement <code>ICollection</code> and are a collection of specific items have names that end with the word 'Collection'. For example, a collection of <code>Queue</code> objects would have the name 'QueueCollection'. The 'Collection' suffix signifies that the members of the collection can be enumerated by using the <code>foreach</code> (<code>For Each</code> in Visual Basic) statement.
+            Types that implement <code>IDictionary</code> have names that end with the word 'Dictionary' even if the type also implements <code>IEnumerable</code> or <code>ICollection</code>. The 'Collection' and 'Dictionary' suffix naming conventions enable users to distinguish between the following two enumeration patterns.
+            Types with the 'Collection' suffix follow this enumeration pattern.
+
+
+
+
+
+
+
+
+
+            <pre>
+    foreach(SomeType x in SomeCollection) { }
+</pre>
+
+
+
+
+Types with the 'Dictionary' suffix follow this enumeration pattern.
+
+
+
+
+
+
+
+
+
+            <pre>
+    foreach(SomeType x in SomeDictionary.Values) { }
+</pre>
+
+
+
+
+A <code>DataSet</code> object consists of a collection of <code>DataTable</code> objects, which consist of collections of <code>System.Data.DataColumn</code> and <code>System.Data.DataRow</code> objects, among others. These collections implement <code>ICollection</code> through the base <code>System.Data.InternalDataCollectionBase</code> class.
+
+
+
+
+
+
+                How to Fix Violations
+
+
+
+
+
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning to use the 'Collection' suffix if the type is a generalized data structure that might be extended or that will hold an arbitrary set of diverse items. In this case, a name that provides meaningful information about the implementation, performance, or other characteristics of the data structure might make sense (for example, BinaryTree). In cases where the type represents a collection of a specific type (for example, StringCollection), do not suppress a warning from this rule because the suffix indicates that the type can be enumerated by using a <code>foreach</code> statement.
+            For other suffixes, do not suppress a warning from this rule. The suffix allows the intended usage to be evident from the type name.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:IdentifiersShouldNotHaveIncorrectSuffix}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182244.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182244.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="IdentifiersShouldNotHaveIncorrectSuffix">
+    <configKey>CA1711</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1711: Identifiers should not have incorrect suffix]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An identifier has an incorrect suffix.
+</p>
+<h2>Rule Description</h2>
+<p>
+            By convention, only the names of types that extend certain base types or that implement certain interfaces, or types derived from these types, should end with specific reserved suffixes. Other type names should not use these reserved suffixes.
+            The following table lists the reserved suffixes and the base types and interfaces with which they are associated.
+
+
+
+
+
+
+
+                    Suffix
+
+
+                    Base type/Interface
+
+
+
+
+                    Attribute
+
+
+
+
+                        <code>System.Attribute</code>
+
+
+
+
+
+
+                    Collection
+
+
+
+
+                        <code>System.Collections.ICollection</code>
+
+
+
+
+                        <code>System.Collections.IEnumerable</code>
+
+
+
+
+                        <code>System.Collections.Queue</code>
+
+
+
+
+                        <code>System.Collections.Stack</code>
+
+
+
+
+                        <code>System.Collections.Generic.ICollection&lt;T&gt;</code>
+
+
+
+
+                        <code>System.Data.DataSet</code>
+
+
+
+
+                        <code>System.Data.DataTable</code>
+
+
+
+
+
+
+                    Dictionary
+
+
+
+
+                        <code>System.Collections.IDictionary</code>
+
+
+
+
+                        System.Collections.Generic.IDictionary&lt;TKey, TValue&gt;
+
+
+
+
+
+
+                    EventArgs
+
+
+
+
+                        <code>System.EventArgs</code>
+
+
+
+
+
+
+                    EventHandler
+
+
+                    An event-handler delegate
+
+
+
+
+                    Exception
+
+
+
+
+                        <code>System.Exception</code>
+
+
+
+
+
+
+                    Permission
+
+
+
+
+                        <code>System.Security.IPermission</code>
+
+
+
+
+
+
+                    Queue
+
+
+
+
+                        <code>System.Collections.Queue</code>
+
+
+
+
+
+
+                    Stack
+
+
+
+
+                        <code>System.Collections.Stack</code>
+
+
+
+
+
+
+                    Stream
+
+
+
+
+                        <code>System.IO.Stream</code>
+
+
+
+
+
+
+            In addition, the following suffixes should not be used:
+            <ul>
+              <li>
+                Delegate
+              </li>
+              <li>
+                Enum
+              </li>
+              <li>
+                Impl - use 'Core' instead
+              </li>
+              <li>
+                Ex or similar suffix to distinguish it from an earlier version of the same type
+              </li>
+            </ul>
+            Naming conventions provide a common look for libraries that target the common language runtime. This reduces the learning curve that is required for new software libraries, and increases customer confidence that the library was developed by someone who has expertise in developing managed code.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Remove the suffix from the type name.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule unless the suffix has an unambiguous meaning in the application domain.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:IdentifiersShouldHaveCorrectSuffix}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182247.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182247.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotPrefixEnumValuesWithTypeName">
+    <configKey>CA1712</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1712: Do not prefix enum values with type name]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An enumeration contains a member whose name starts with the type name of the enumeration.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Names of enumeration members are not prefixed with the type name because type information is expected to be provided by development tools.
+            Naming conventions provide a common look for libraries that target the common language runtime. This reduces the time that is required for to learn a new software library, and increases customer confidence that the library was developed by someone who has expertise in developing managed code.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, remove the type name prefix from the enumeration member.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:IdentifiersShouldNotHaveIncorrectSuffix}<br/>
+
+
+
+
+                {rule:fxcop:MarkEnumsWithFlags}<br/>
+
+
+
+
+                {rule:fxcop:DoNotMarkEnumsWithFlags}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182237.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182237.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="EventsShouldNotHaveBeforeOrAfterPrefix">
+    <configKey>CA1713</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1713: Events should not have before or after prefix]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The name of an event starts with 'Before' or 'After'.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Event names should describe the action that raises the event. To name related events that are raised in a specific sequence, use the present or past tense to indicate the relative position in the sequence of actions. For example, when naming a pair of events that is raised when closing a resource, you might name it 'Closing' and 'Closed', instead of 'BeforeClose' and 'AfterClose'.
+            Naming conventions provide a common look for libraries that target the common language runtime. This reduces the learning curve that is required for new software libraries, and increases customer confidence that the library was developed by someone who has expertise in developing managed code.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Remove the prefix from the event name, and consider changing the name to use the present or past tense of a verb.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182238.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182238.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="FlagsEnumsShouldHavePluralNames">
+    <configKey>CA1714</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1714: Flags enums should have plural names]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public enumeration has the <code>System.FlagsAttribute</code> and its name does not end in 's'.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Types that are marked with <code>FlagsAttribute</code> have names that are plural because the attribute indicates that more than one value can be specified. For example, an enumeration that defines the days of the week might be intended for use in an application where you can specify multiple days. This enumeration should have the <code>FlagsAttribute</code> and could be called 'Days'. A similar enumeration that allows only a single day to be specified would not have the attribute, and could be called 'Day'.
+            Naming conventions provide a common look for libraries that target the common language runtime. This reduces the learning curve that is required for new software libraries, and increases customer confidence that the library was developed by someone who has expertise in developing managed code.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Make the name of the enumeration a plural word, or remove the <code>FlagsAttribute</code> attribute if multiple enumeration values should not be specified simultaneously.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a violation if the name is a plural word but does not end in 's'. For example, if the multiple-day enumeration that was described previously were named 'DaysOfTheWeek', this would violate the logic of the rule but not its intent. Such violations should be suppressd.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:MarkEnumsWithFlags}<br/>
+
+
+
+
+                {rule:fxcop:DoNotMarkEnumsWithFlags}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb264486.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb264486.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="IdentifiersShouldHaveCorrectPrefix">
+    <configKey>CA1715</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1715: Identifiers should have correct prefix]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The name of an externally visible interface does not start with an uppercase 'I'.
+            -or-
+            The name of a generic type parameter on an externally visible type or method does not start with an uppercase 'T'.
+</p>
+<h2>Rule Description</h2>
+<p>
+            By convention, the names of certain programming elements start with a specific prefix.
+            Interface names should start with an uppercase 'I' followed by another uppercase letter. This rule reports violations for interface names such as 'MyInterface' and 'IsolatedInterface'.
+            Generic type parameter names should start with an uppercase 'T' and optionally may be followed by another uppercase letter. This rule reports violations for generic type parameter names such as 'V' and 'Type'.
+            Naming conventions provide a common look for libraries that target the common language runtime. This reduces the learning curve that is required for new software libraries, and increases customer confidence that the library was developed by someone who has expertise in developing managed code.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Rename the identifier so that it is correctly prefixed.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:IdentifiersShouldNotHaveIncorrectPrefix}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182243.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182243.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="IdentifiersShouldNotMatchKeywords">
+    <configKey>CA1716</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1716: Identifiers should not match keywords]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A name of a namespace, a type, or a viritual or interface member matches a reserved keyword in a programming language.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Identifiers for namespaces, types, and virtual and interface members should not match keywords that are defined by languages that target the common language runtime. Depending on the language that is used and the keyword, compiler errors and ambiguities can make the library difficult to use.
+            This rule checks against keywords in the following languages:
+            <ul>
+              <li>
+                Visual Basic
+              </li>
+              <li>
+                C#
+              </li>
+              <li>
+                C++/CLI
+              </li>
+            </ul>
+            Case-insensitive comparison is used for Visual Basic keywords, and case-sensitive comparison is used for the other languages.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Select a name that does not appear in the list of keywords.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            You can suppress a warning from this rule if you are convinced that the identifier will not confuse users of the API, and that  the library is usable in all available languages in the .NET Framework.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182248.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182248.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="OnlyFlagsEnumsShouldHavePluralNames">
+    <configKey>CA1717</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1717: Only FlagsAttribute enums should have plural names]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The name of an externally visible enumeration ends in a plural word and the enumeration is not marked with the <code>System.FlagsAttribute</code> attribute.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Naming conventions dictate that a plural name for an enumeration indicates that more than one value of the enumeration can be specified simultaneously. The <code>FlagsAttribute</code> tells compilers that the enumeration should be treated as a bit field that enables bitwise operations on the enumeration.
+            If only one value of an enumeration can be specified at a time, the name of the enumeration should be a singular word. For example, an enumeration that defines the days of the week might be intended for use in an application where you can specify multiple days. This enumeration should have the <code>FlagsAttribute</code> and could be called 'Days'. A similar enumeration that allows only a single day to be specified would not have the attribute, and could be called 'Day'.
+            Naming conventions provide a common look for libraries that target the common language runtime. This reduces the time that is required to learn a new software library, and increases customer confidence that the library was developed by someone who has expertise in developing managed code.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Make the name of the enumeration a singular word or add the <code>FlagsAttribute</code>.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from the rule if the name ends in a singular word.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                CA1714: Flags enums should have plural names
+
+
+
+
+                {rule:fxcop:MarkEnumsWithFlags}<br/>
+
+
+
+
+                {rule:fxcop:DoNotMarkEnumsWithFlags}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb264487.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb264487.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ParameterNamesShouldNotMatchMemberNames">
+    <configKey>CA1719</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1719: Parameter names should not match member names]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The name of an externally visible member matches, in a case-insensitive comparison, the name of one of its parameters.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A parameter name should communicate the meaning of a parameter and a member name should communicate the meaning of a member. It would be a rare design where these were the same. Naming a parameter the same as its member name is unintuitive and makes the library difficult to use.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Select a parameter name that does not match the member name.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            For new development, no known scenarios occur where you must suppress a warning from this rule. For shipping libraries, you might have to suppress a warning from this rule.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:IdentifiersShouldBeCasedCorrectly}<br/>
+
+
+
+
+                {rule:fxcop:IdentifiersShouldDifferByMoreThanCase}<br/>
+
+
+
+
+                {rule:fxcop:IdentifiersShouldNotContainUnderscores}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182252.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182252.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="IdentifiersShouldNotContainTypeNames">
+    <configKey>CA1720</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1720: Identifiers should not contain type names]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The name of a parameter in an externally visible member contains a data type name.
+            -or-
+            The name of an externally visible member contains a language-specific data type name.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Names of parameters and members are better used to communicate their meaning than to describe their type, which is expected to be provided by development tools. For names of members, if a data type name must be used, use a language-independent name instead of a language-specific one. For example, instead of the C# type name 'int', use the language-independent data type name, Int32.
+            Each discrete token in the name of the parameter or member is checked against the following language-specific data type names, in a case-insensitive manner:
+            <ul>
+              <li>
+                Bool
+              </li>
+              <li>
+                WChar
+              </li>
+              <li>
+                Int8
+              </li>
+              <li>
+                UInt8
+              </li>
+              <li>
+                Short
+              </li>
+              <li>
+                UShort
+              </li>
+              <li>
+                Int
+              </li>
+              <li>
+                UInt
+              </li>
+              <li>
+                Integer
+              </li>
+              <li>
+                UInteger
+              </li>
+              <li>
+                Long
+              </li>
+              <li>
+                ULong
+              </li>
+              <li>
+                Unsigned
+              </li>
+              <li>
+                Signed
+              </li>
+              <li>
+                Float
+              </li>
+              <li>
+                Float32
+              </li>
+              <li>
+                Float64
+              </li>
+            </ul>
+            In addition, the names of a parameter are also checked against the following language-independent data type names, in a case-insensitive manner:
+            <ul>
+              <li>
+                Object
+              </li>
+              <li>
+                Obj
+              </li>
+              <li>
+                Boolean
+              </li>
+              <li>
+                Char
+              </li>
+              <li>
+                String
+              </li>
+              <li>
+                SByte
+              </li>
+              <li>
+                Byte
+              </li>
+              <li>
+                UByte
+              </li>
+              <li>
+                Int16
+              </li>
+              <li>
+                UInt16
+              </li>
+              <li>
+                Int32
+              </li>
+              <li>
+                UInt32
+              </li>
+              <li>
+                Int64
+              </li>
+              <li>
+                UInt64
+              </li>
+              <li>
+                IntPtr
+              </li>
+              <li>
+                Ptr
+              </li>
+              <li>
+                Pointer
+              </li>
+              <li>
+                UInptr
+              </li>
+              <li>
+                UPtr
+              </li>
+              <li>
+                UPointer
+              </li>
+              <li>
+                Single
+              </li>
+              <li>
+                Double
+              </li>
+              <li>
+                Decimal
+              </li>
+              <li>
+                Guid
+              </li>
+            </ul>
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+
+              If fired against a parameter:
+
+            Replace the data type identifier in the name of the parameter with either a term that better describes its meaning or a more generic term, such as 'value'.
+
+              If fired against a member:
+
+            Replace the language-specific data type identifier in the name of the member with a term that better describes its meaning, a language-independent equivalent, or a more generic term, such as 'value'.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Occasional use of type-based parameter and member names might be appropriate. However, for new development, no known scenarios occur where you should suppress a warning from this rule. For libraries that have previous shipped, you might have to suppress a warning from this rule.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:IdentifiersShouldBeCasedCorrectly}<br/>
+
+
+
+
+                {rule:fxcop:IdentifiersShouldDifferByMoreThanCase}<br/>
+
+
+
+
+                {rule:fxcop:IdentifiersShouldNotContainUnderscores}<br/>
+
+
+
+
+                {rule:fxcop:ParameterNamesShouldNotMatchMemberNames}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb531486.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb531486.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="PropertyNamesShouldNotMatchGetMethods">
+    <configKey>CA1721</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1721: Property names should not match get methods]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The name of a public or protected member starts with 'Get' and otherwise matches the name of a public or protected property. For example, a type that contains a method that is named 'GetColor' and a property that is named 'Color' violates this rule.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Get methods and properties should have names that clearly distinguish their function.
+            Naming conventions provide a common look for libraries that target the common language runtime. This reduces the time that is required to learn a new software library, and increases customer confidence that the library was developed by someone who has expertise in developing managed code.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Change the name so that it does not match the name of a method that is prefixed with 'Get'.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+
+
+
+
+
+                    Note
+
+
+
+
+                    This warning may be excluded if the Get method is caused by implementing IExtenderProvider interface.
+
+
+
+
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:UsePropertiesWhereAppropriate}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182253.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182253.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="IdentifiersShouldNotHaveIncorrectPrefix">
+    <configKey>CA1722</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1722: Identifiers should not have incorrect prefix]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An identifier has an incorrect prefix.
+</p>
+<h2>Rule Description</h2>
+<p>
+            By convention, only certain programming elements have names that begin with a specific prefix.
+            Type names do not have a specific prefix and should not be prefixed with a 'C'. This rule reports violations for type names such as 'CMyClass' and does not report violations for type names such as 'Cache'.
+            Naming conventions provide a common look for libraries that target the common language runtime. This reduces the learning curve that is required for new software libraries, and increases customer confidence that the library was developed by someone who has expertise in developing managed code.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Remove the prefix from the identifier.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:IdentifiersShouldHaveCorrectPrefix}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182246.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182246.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="TypeNamesShouldNotMatchNamespaces">
+    <configKey>CA1724</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1724: Type Names Should Not Match Namespaces]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type name matches a .NET Framework namespace names in a case-insensitive comparison.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Type names should not match the names of namespaces that are defined in the .NET Framework class library. Violating this rule can reduce the usability of the library.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Select a type name that does not match the name of a .NET Framework class library namespace.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            For new development, no known scenarios occur where you must suppress a warning from this rule. Before you suppress the warning, carefully consider how the users of your library might be confused by the matching name. For shipping libraries, you might have to suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182257.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182257.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ParameterNamesShouldMatchBaseDeclaration">
+    <configKey>CA1725</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1725: Parameter names should match base declaration]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The name of a parameter in an externally visible method override does not match the name of the parameter in the base declaration of the method, or the name of the parameter in the interface declaration of the method.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Consistent naming of parameters in an override hierarchy increases the usability of the method overrides. A parameter name in a derived method that differs from the name in the base declaration can cause confusion about whether the method is an override of the base method or a new overload of the method.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, rename the parameter to match the base declaration. The fix is a breaking change for COM visible methods.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule except for COM visible methods in libraries that have previously shipped.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182251.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182251.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="UsePreferredTerms">
+    <configKey>CA1726</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1726: Use preferred terms]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The name of an externally visible identifier includes a term for which an alternative, preferred term exists. Alternatively, the name includes the term Flag or Flags.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule parses an identifier into tokens. Each single token and each contiguous dual token combination is compared to terms that are built into the rule and in the Deprecated section of any custom dictionaries. The following table shows the terms that are built into the rule and their preferred alternatives.
+
+
+
+
+
+
+
+                    Obsolete term
+
+
+                    Preferred term
+
+
+
+
+                    Arent
+
+
+                    AreNot
+
+
+
+
+                    Cancelled
+
+
+                    Canceled
+
+
+
+
+                    Cant
+
+
+                    Cannot
+
+
+
+
+                    ComPlus
+
+
+                    EnterpriseServices
+
+
+
+
+                    Couldnt
+
+
+                    CouldNot
+
+
+
+
+                    Didnt
+
+
+                    DidNot
+
+
+
+
+                    Doesnt
+
+
+                    DoesNot
+
+
+
+
+                    Dont
+
+
+                    DoNot
+
+
+
+
+                    Flag or Flags
+
+
+                    There is no replacement term. Do not use.
+
+
+
+
+                    Hadnt
+
+
+                    HadNot
+
+
+
+
+                    Hasn’t
+
+
+                    HasNot
+
+
+
+
+                    Havent
+
+
+                    HaveNot
+
+
+
+
+                    Indices
+
+
+                    Indexes
+
+
+
+
+                    Isnt
+
+
+                    IsNot
+
+
+
+
+                    LogIn
+
+
+                    LogOn
+
+
+
+
+                    LogOut
+
+
+                    LogOff
+
+
+
+
+                    Shouldnt
+
+
+                    ShouldNot
+
+
+
+
+                    SignOn
+
+
+                    SignIn
+
+
+
+
+                    SignOff
+
+
+                    SignOut
+
+
+
+
+                    Wasnt
+
+
+                    WasNot
+
+
+
+
+                    Werent
+
+
+                    WereNot
+
+
+
+
+                    Wont
+
+
+                    WillNot
+
+
+
+
+                    Wouldnt
+
+
+                    WouldNot
+
+
+
+
+                    Writeable
+
+
+                    Writable
+
+
+
+
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, replace the term with the preferred alternative term.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Suppress a warning from this rule only if the name of the identifier is intentional and relates specifically to the original term instead of the preferred term.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                Naming Warnings
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182258.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182258.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotCastUnnecessarily">
+    <configKey>CA1800</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1800: Do not cast unnecessarily]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method performs duplicate casts on one of its arguments or local variables. For complete analysis by this rule, the tested assembly must be built by using debugging information and the associated program database (.pdb) file must be available.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Duplicate casts decrease performance, especially when the casts are performed in compact iteration statements. For explicit duplicate cast operations, store the result of the cast in a local variable and use the local variable instead of the duplicate cast operations.
+            If the C# <code>is</code> operator is used to test whether the cast will succeed before the actual cast is performed, consider testing the result of the <code>as</code> operator instead. This provides the same functionality without the implicit cast operation that is performed by the <code>is</code> operator.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, modify the method implementation to minimize the number of cast operations.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule, or to ignore the rule completely, if performance is not a concern.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182271.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182271.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ReviewUnusedParameters">
+    <configKey>CA1801</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1801: Review unused parameters]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method signature includes a parameter that is not used in the method body. This rule does not examine the following methods:
+            <ul>
+              <li>
+                Methods referenced by a delegate.
+              </li>
+              <li>
+                Methods used as event handlers.
+              </li>
+              <li>
+                Methods declared with the <code>abstract</code> (<code>MustOverride</code> in Visual Basic) modifier.
+              </li>
+              <li>
+                Methods declared with the <code>virtual</code> (<code>Overridable</code> in Visual Basic) modifier.
+              </li>
+              <li>
+                Methods declared with the <code>override</code> (<code>Overrides</code> in Visual Basic) modifier.
+              </li>
+              <li>
+                Methods declared with the <code>extern</code> (<code>Declare</code> statement in Visual Basic) modifier.
+              </li>
+            </ul>
+</p>
+<h2>Rule Description</h2>
+<p>
+            Review parameters in non-virtual methods that are not used in the method body to make sure no correctness exists around failure to access them. Unused parameters incur maintenance and performance costs.
+            Sometimes a violation of this rule can point to an implementation bug in the method. For example, the parameter should have been used in the method body. Suppress warnings of this rule if the parameter has to exist because of backward compatibility.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, remove the unused parameter (a breaking change) or use the parameter in the method body (a non-breaking change).
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule for previously shipped code for which the fix would be a breaking change.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:AvoidUncalledPrivateCode}<br/>
+
+
+
+
+                {rule:fxcop:AvoidUninstantiatedInternalClasses}<br/>
+
+
+
+
+                {rule:fxcop:RemoveUnusedLocals}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182268.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182268.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="UseLiteralsWhereAppropriate">
+    <configKey>CA1802</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1802: Use Literals Where Appropriate]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A field is declared <code>static</code> and <code>readonly</code> (<code>Shared</code> and <code>ReadOnly</code> in Visual Basic), and is initialized with a value that is computable at compile time.
+</p>
+<h2>Rule Description</h2>
+<p>
+            The value of a <code>static</code> <code>readonly</code> field is computed at runtime when the static constructor for the declaring type is called. If the <code>static</code> <code>readonly</code> field is initialized when it is declared and a static constructor is not declared explicitly, the compiler emits a static constructor to initialize the field.
+            The value of a <code>const</code> field is computed at compile time and stored in the metadata, which increases runtime performance when it is compared to a <code>static</code> <code>readonly</code> field.
+            Because the value assigned to the targeted field is computable at compile time, change the declaration to a <code>const</code> field so that the value is computed at compile time instead of at runtime.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, replace the <code>static</code> and <code>readonly</code> modifiers with the <code>const</code> modifier.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule, or disable the rule, if performance is not of concern.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182280.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182280.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="RemoveUnusedLocals">
+    <configKey>CA1804</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1804: Remove unused locals]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method declares a local variable but does not use the variable except possibly as the recipient of an assignment statement. For analysis by this rule, the tested assembly must be built with debugging information and the associated program database (.pdb) file must be available.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Unused local variables and unnecessary assignments increase the size of an assembly and decrease performance.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, remove or use the local variable. Note that the C# compiler that is included with .NET Framework 2.0 removes unused local variables when the <code>optimize</code> option is enabled.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Suppress a warning from this rule if the variable was compiler emitted. It is also safe to suppress a warning from this rule, or to disable the rule, if performance and code maintenance are not primary concerns.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:AvoidExcessiveLocals}<br/>
+
+
+
+
+                {rule:fxcop:AvoidUncalledPrivateCode}<br/>
+
+
+
+
+                {rule:fxcop:AvoidUninstantiatedInternalClasses}<br/>
+
+
+
+
+                {rule:fxcop:ReviewUnusedParameters}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182278.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182278.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotIgnoreMethodResults">
+    <configKey>CA1806</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1806: Do not ignore method results]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            There are several possible reasons for this warning:
+            <ul>
+              <li>
+                A new object is created but never used.
+              </li>
+              <li>
+                A method that creates and returns a new string is called and the new string is never used.
+              </li>
+              <li>
+                A COM or P/Invoke method that returns a HRESULT or error code that is never used. Rule Description
+              </li>
+            </ul>
+            Unnecessary object creation and the associated garbage collection of the unused object degrade performance.
+            Strings are immutable and methods such as String.ToUpper returns a new instance of a string instead of modifying the instance of the string in the calling method.
+            Ignoring HRESULT or error code can lead to unexpected behavior in error conditions or to low-resource conditions.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            If method A creates a new instance of B object that is never used, pass the instance as an argument to another method or assign the instance to a variable. If the object creation is unnecessary, remove the it.-or-
+            If method A calls method B, but does not use the new string instance that the method B returns. Pass the instance as an argument to another method, assign the instance to a variable. Or remove the call if it is unnecessary.
+            -or-
+            If method A calls method B, but does not use the HRESULT or error code that the method returns. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule unless the act of creating the object serves some purpose.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182273.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182273.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AvoidExcessiveLocals">
+    <configKey>CA1809</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1809: Avoid excessive locals]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A member contains more than 64 local variables, some of which might be compiler-generated.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A common performance optimization is to store a value in a processor register instead of in memory, which is referred to as enregistering the value. The common language runtime considers up to 64 local variables for enregistration. Variables that are not enregistered are put on the stack and must be moved to a register before manipulation. To allow the chance that all local variables get enregistered, limit the number of local variables to 64.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, refactor the implementation to use no more than 64 local variables.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule, or to disable the rule, if performance is not an issue.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:RemoveUnusedLocals}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182263.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182263.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="InitializeReferenceTypeStaticFieldsInline">
+    <configKey>CA1810</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1810: Initialize reference type static fields inline]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A reference type declares an explicit static constructor.
+</p>
+<h2>Rule Description</h2>
+<p>
+            When a type declares an explicit static constructor, the just-in-time (JIT) compiler adds a check to each static method and instance constructor of the type to make sure that the static constructor was previously called. Static initialization is triggered when any static member is accessed or when an instance of the type is created. However, static initialization is not triggered if you declare a variable of the type but do not use it, which can be important if the initialization changes global state.
+            When all static data is initialized inline and an explicit static constructor is not declared, Microsoft intermediate language (MSIL) compilers add the <code>beforefieldinit</code> flag and an implicit static constructor, which initializes the static data, to the MSIL type definition. When the JIT compiler encounters the <code>beforefieldinit</code> flag, most of the time the static constructor checks are not added. Static initialization is guaranteed to occur at some time before any static fields are accessed but not before a static method or instance constructor is invoked. Note that static initialization can occur at any time after a variable of the type is declared.
+            Static constructor checks can decrease performance. Often a static constructor is used only to initialize static fields, in which case you must only make sure that static initialization occurs before the first access of a static field. The <code>beforefieldinit</code> behavior is appropriate for these and most other types. It is only inappropriate when static initialization affects global state and one of the following is true:
+            <ul>
+              <li>
+                The effect on global state is expensive and is not required if the type is not used.
+              </li>
+              <li>
+                The global state effects can be accessed without accessing any static fields of the type.
+              </li>
+            </ul>
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, initialize all static data when it is declared and remove the static constructor.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if performance is not a concern; or if global state changes that are caused by static initialization are expensive or must be guaranteed to occur before a static method of the type is called or an instance of the type is created.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:InitializeValueTypeStaticFieldsInline}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182275.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182275.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AvoidUncalledPrivateCode">
+    <configKey>CA1811</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1811: Avoid uncalled private code]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A private or internal (assembly-level) member does not have callers in the assembly, is not invoked by the common language runtime, and is not invoked by a delegate. The following members are not checked by this rule:
+            <ul>
+              <li>
+                Explicit interface members.
+              </li>
+              <li>
+                Static constructors.
+              </li>
+              <li>
+                Serialization constructors.
+              </li>
+              <li>
+                Methods marked with <code>System.Runtime.InteropServices.ComRegisterFunctionAttribute</code> or <code>System.Runtime.InteropServices.ComUnregisterFunctionAttribute</code>.
+              </li>
+              <li>
+                Members that are overrides.
+              </li>
+            </ul>
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule can report false positives if entry points occur that are not currently identified by the rule logic. Also, a compiler may emit noncallable code into an assembly.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, remove the noncallable code or add code that calls it.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:AvoidUninstantiatedInternalClasses}<br/>
+
+
+
+
+                {rule:fxcop:ReviewUnusedParameters}<br/>
+
+
+
+
+                {rule:fxcop:RemoveUnusedLocals}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182264.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182264.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AvoidUninstantiatedInternalClasses">
+    <configKey>CA1812</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1812: Avoid uninstantiated internal classes]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An instance of an assembly-level type is not created by code in the assembly.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule tries to locate a call to one of the constructors of the type, and reports a violation if no call is found.
+            The following types are not examined by this rule:
+            <ul>
+              <li>
+                Value types
+              </li>
+              <li>
+                Abstract types
+              </li>
+              <li>
+                Enumerations
+              </li>
+              <li>
+                Delegates
+              </li>
+              <li>
+                Compiler-emitted array types
+              </li>
+              <li>
+                Types that cannot be instantiated and that define <code>static</code> (<code>Shared</code> in Visual Basic) methods only.
+              </li>
+            </ul>
+            If you apply <code>System.Runtime.CompilerServices.InternalsVisibleToAttribute</code> to the assembly that is being analyzed, this rule will not occur on any constructors that are marked as <code>internal</code> because you cannot tell whether a field is being used by another <code>friend</code> assembly.
+            Even though you cannot work around this limitation in Visual Studio Code Analysis, the external stand-alone FxCop will occur on internal constructors if every <code>friend</code> assembly is present in the analysis.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, remove the type or add the code that uses it. If the type contains only static methods, add one of the following to the type to prevent the compiler from emitting a default public instance constructor:
+            <ul>
+              <li>
+                A private constructor for types that target .NET Framework versions 1.0 and 1.1.
+              </li>
+              <li>
+                The <code>static</code> (<code>Shared</code> in Visual Basic) modifier for types that target .NET Framework 2.0.
+              </li>
+            </ul>
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule. We recommend that you suppress this warning in the following situations:
+            <ul>
+              <li>
+                The class is created through late-bound reflection methods such as CreateInstance.
+              </li>
+              <li>
+                The class is created automatically by the runtime or ASP.NET. For example, classes that implement <code>System.Configuration.IConfigurationSectionHandler</code> or <code>System.Web.IHttpHandler</code>.
+              </li>
+              <li>
+                The class is passed as a generic type parameter that has a new constraint. For example, the following example will raise this rule.
+
+
+
+
+
+
+
+
+
+            <pre>
+internal class MyClass
+{
+    public DoSomething()
+    {
+    }
+}
+public class MyGeneric&lt;T&gt; where T : new()
+{
+    public T Create()
+    {
+        return new T();
+    }
+}
+// [...]
+MyGeneric&lt;MyClass&gt; mc = new MyGeneric&lt;MyClass&gt;();
+mc.Create();
+</pre>
+
+
+
+
+</li>
+            </ul>
+            In these situations, we recommended you suppress this warning.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:AvoidUncalledPrivateCode}<br/>
+
+
+
+
+                {rule:fxcop:ReviewUnusedParameters}<br/>
+
+
+
+
+                {rule:fxcop:RemoveUnusedLocals}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182265.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182265.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AvoidUnsealedAttributes">
+    <configKey>CA1813</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1813: Avoid unsealed attributes]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public type inherits from <code>System.Attribute</code>, is not abstract, and is not sealed (<code>NotInheritable</code> in Visual Basic).
+</p>
+<h2>Rule Description</h2>
+<p>
+            The .NET Framework class library provides methods for retrieving custom attributes. By default, these methods search the attribute inheritance hierarchy; for example <code>Attribute.GetCustomAttribute</code> searches for the specified attribute type, or any attribute type that extends the specified attribute type. Sealing the attribute eliminates the search through the inheritance hierarchy, and can improve performance.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, seal the attribute type or make it abstract.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule. You should do this only if you are defining an attribute hierarchy and cannot seal the attribute or make it abstract.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:DefineAccessorsForAttributeArguments}<br/>
+
+
+
+
+                {rule:fxcop:MarkAttributesWithAttributeUsage}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182267.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182267.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="PreferJaggedArraysOverMultidimensional">
+    <configKey>CA1814</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1814: Prefer jagged arrays over multidimensional]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A member is declared as a multidimensional array.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A jagged array is an array whose elements are arrays. The arrays that make up the elements can be of different sizes, leading to less wasted space for some sets of data.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the multidimensional array to a jagged array.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Suppress a warning from this rule if the multidimensional array does not waste space.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182277.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182277.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="OverrideEqualsAndOperatorEqualsOnValueTypes">
+    <configKey>CA1815</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1815: Override equals and operator equals on value types]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public value type does not override <code>Object.Equals</code>, or does not implement the equality operator (==). This rule does not check enumerations.
+</p>
+<h2>Rule Description</h2>
+<p>
+            For value types, the inherited implementation of <code>Equals</code> uses the Reflection library, and compares the contents of all fields. Reflection is computationally expensive, and comparing every field for equality might be unnecessary. If you expect users to compare or sort instances, or use them as hash table keys, your value type should implement <code>Equals</code>. If your programming language supports operator overloading, you should also provide an implementation of the equality and inequality operators.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, provide an implementation of <code>Equals</code>. If you can, implement the equality operator.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if instances of the value type will not be compared to each other.
+</p>
+<h2>Example of a Violation</h2>
+
+<h3>Description</h3>
+<p>
+                The following example shows a structure (value type) that violates this rule.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+
+namespace Samples
+{
+    // Violates this rule     
+    public struct Point
+    {
+        private readonly int _X;
+        private readonly int _Y;
+
+        public Point(int x, int y)
+        {
+            _X = x;
+            _Y = y;
+        }
+
+        public int X
+        {
+            get { return _X; }
+        }
+
+        public int Y
+        {
+            get { return _Y; }
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>Example of How to Fix</h2>
+
+<h3>Description</h3>
+<p>
+                The following example fixes the previous violation by overriding ValueType.Equals and implementing the equality operators (==, !=).
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+
+namespace Samples
+{
+    public struct Point : IEquatable&lt;Point&gt;
+    {
+        private readonly int _X;
+        private readonly int _Y;
+
+        public Point(int x, int y)
+        {
+            _X = x;
+            _Y = y;
+        }
+
+        public int X
+        {
+            get { return _X; }
+        }
+
+        public int Y
+        {
+            get { return _Y; }
+        }
+
+        public override int GetHashCode()
+        {
+            return _X ^ _Y;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is Point))
+                return false;
+
+            return Equals((Point)obj);
+        }
+
+        public bool Equals(Point other)
+        {
+            if (_X != other._X)
+                return false;
+
+            return _Y == other._Y;
+        }
+
+        public static bool operator ==(Point point1, Point point2)
+        {
+            return point1.Equals(point2);
+        }
+
+        public static bool operator !=(Point point1, Point point2)
+        {
+            return !point1.Equals(point2);
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:OverrideEqualsOnOverloadingOperatorEquals}<br/>
+
+
+
+
+                {rule:fxcop:OverloadOperatorEqualsOnOverridingValueTypeEquals}<br/>
+
+
+
+
+                {rule:fxcop:OperatorsShouldHaveSymmetricalOverloads}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182276.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182276.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="CallGCSuppressFinalizeCorrectly">
+    <configKey>CA1816</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1816: Call GC.SuppressFinalize correctly]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            <ul>
+              <li>
+                A method that is an implementation of <code>IDisposable.Dispose</code> does not call <code>GC.SuppressFinalize</code>.
+              </li>
+              <li>
+                A method that is not an implementation of <code>IDisposable.Dispose</code> calls <code>GC.SuppressFinalize</code>.
+              </li>
+              <li>
+                A method calls <code>GC.SuppressFinalize</code> and passes something other than this (Me in Visual Basic).
+              </li>
+            </ul>
+</p>
+<h2>Rule Description</h2>
+<p>
+            The <code>IDisposable.Dispose</code> method lets users release resources at any time before the object becoming available for garbage collection. If the <code>IDisposable.Dispose</code> method is called, it frees resources of the object. This makes finalization unnecessary. <code>IDisposable.Dispose</code> should call <code>GC.SuppressFinalize</code> so the garbage collector does not call the finalizer of the object.
+             
+            To prevent derived types with finalizers from having to re-implement [System.IDisposable] and to call it, unsealed types without finalizers should still call <code>GC.SuppressFinalize</code>.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule:
+            If the method is an implementation of <code>Dispose</code>, add a call to <code>GC.SuppressFinalize</code>.
+            If the method is not an implementation of <code>Dispose</code>, either remove the call to <code>GC.SuppressFinalize</code> or move it to the type's <code>Dispose</code> implementation.
+            Change all calls to <code>GC.SuppressFinalize</code> to pass this (Me in Visual Basic).
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Only suppress a warning from this rule if you are deliberating using <code>GC.SuppressFinalize</code> to control the lifetime of other objects. Do not suppress a warning from this rule if an implementation of <code>Dispose</code> does not call <code>GC.SuppressFinalize</code>. In this situation, failing to suppress finalization degrades performance and provide no benefits.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:DisposeMethodsShouldCallBaseClassDispose}<br/>
+
+
+
+
+                {rule:fxcop:DisposableTypesShouldDeclareFinalizer}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182269.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182269.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="PropertiesShouldNotReturnArrays">
+    <configKey>CA1819</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1819: Properties should not return arrays]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected property in a public type returns an array.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Arrays returned by properties are not write-protected, even if the property is read-only. To keep the array tamper-proof, the property must return a copy of the array. Typically, users will not understand the adverse performance implications of calling such a property. Specifically, they might use the property as an indexed property.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, either make the property a method or change the property to return a collection.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Attributes can contain properties that return arrays, but cannot contain properties that return collections. You can suppress a warning that is raised for a property of an attribute that is derived from the [System.Attribute] class. Otherwise, do not suppress a warning from this rule.
+</p>
+<h2>Example Violation</h2>
+
+<h3>Description</h3>
+<p>
+                The following example shows a property that violates this rule.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+
+namespace PerformanceLibrary
+{
+    public class Book
+    {
+        private string[] _Pages;
+
+        public Book(string[] pages)
+        {
+            _Pages = pages;
+        }
+
+        public string[] Pages
+        {
+            get { return _Pages; }
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h3>Comments</h3>
+<p>
+                To fix a violation of this rule, either make the property a method or change the property to return a collection instead of an array.
+</p>
+<h2>Change the Property to a Method Example</h2>
+
+<h3>Description</h3>
+<p>
+                The following example fixes the violation by changing the property to a method.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+
+namespace PerformanceLibrary
+{
+    public class Book
+    {
+        private string[] _Pages;
+
+        public Book(string[] pages)
+        {
+            _Pages = pages;
+        }
+
+        public string[] GetPages()
+        {
+            // Need to return a clone of the array so that consumers             
+            // of this library cannot change its contents             
+            return (string[])_Pages.Clone();
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>Return a Collection Example</h2>
+
+<h3>Description</h3>
+<p>
+                The following example fixes the violation by changing the property to return a
+
+                  ReadOnlyCollection.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+using System.Collections.ObjectModel;
+
+namespace PerformanceLibrary
+{
+    public class Book
+    {
+        private ReadOnlyCollection&lt;string&gt; _Pages;
+        public Book(string[] pages)
+        {
+            _Pages = new ReadOnlyCollection&lt;string&gt;(pages);
+        }
+
+        public ReadOnlyCollection&lt;string&gt; Pages
+        {
+            get { return _Pages; }
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>Allowing Users to Modify a Property</h2>
+
+<h3>Description</h3>
+<p>
+                You might want to allow the consumer of the class to modify a property. The following example shows a read/write property that violates this rule.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+
+namespace PerformanceLibrary
+{
+    public class Book
+    {
+        private string[] _Pages;
+
+        public Book(string[] pages)
+        {
+            _Pages = pages;
+        }
+
+        public string[] Pages
+        {
+            get { return _Pages; }
+            set { _Pages = value; }
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h3>Comments</h3>
+<p>
+                The following example fixes the violation by changing the property to return a Collection.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+using System.Collections.ObjectModel;
+
+namespace PerformanceLibrary
+{
+    public class Book
+    {
+        private Collection&lt;string&gt; _Pages;
+
+        public Book(string[] pages)
+        {
+            _Pages = new Collection&lt;string&gt;(pages);
+        }
+
+        public Collection&lt;string&gt; Pages
+        {
+            get { return _Pages; }
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:UsePropertiesWhereAppropriate}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/0fss9skc.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/0fss9skc.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="TestForEmptyStringsUsingStringLength">
+    <configKey>CA1820</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1820: Test for empty strings using string length]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A string is compared to the empty string by using <code>Object.Equals</code>.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Comparing strings using the <code>String.Length</code> property or the <code>String.IsNullOrEmpty</code> method is significantly faster than using <code>Equals</code>. This is because <code>Equals</code> executes significantly more MSIL instructions than either <code>IsNullOrEmpty</code> or the number of instructions executed to retrieve the <code>Length</code> property value and compare it to zero.
+            You should be aware that <code>Equals</code> and <code>Length</code> == 0 behave differently for null strings. If you try to get the value of the <code>Length</code> property on a null string, the common language runtime throws a <code>System.NullReferenceException</code>. If you perform a comparison between a null string and the empty string, the common language runtime does not throw an exception; the comparison returns <code>false</code>. Testing for null does not significantly affect the relative performance of these two approaches. When targeting .NET Framework 2.0, use the <code>IsNullOrEmpty</code> method. Otherwise, use the <code>Length</code> == comparison whenever possible.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the comparison to use the <code>Length</code> property and test for the null string. If targeting .NET Framework 2.0, use the <code>IsNullOrEmpty</code> method.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if performance is not an issue.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182279.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182279.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="RemoveEmptyFinalizers">
+    <configKey>CA1821</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1821: Remove empty finalizers]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type implements a finalizer that is empty, calls only the base type finalizer, or calls only conditionally emitted methods.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Whenever you can, avoid finalizers because of the additional performance overhead that is involved in tracking object lifetime. The garbage collector will run the finalizer before it collects the object. This means that two collections will be required to collect the object. An empty finalizer incurs this added overhead without any benefit.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Remove the empty finalizer. If a finalizer is required for debugging, enclose the whole finalizer in #if DEBUG / #endif directives.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a message from this rule. Failure to suppress finalization decreases performance and provides no benefits.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb264476.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb264476.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="MarkMembersAsStatic">
+    <configKey>CA1822</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1822: Mark members as static]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A member that does not access instance data is not marked as static (Shared in Visual Basic).
+</p>
+<h2>Rule Description</h2>
+<p>
+            Members that do not access instance data or call instance methods can be marked as static (Shared in Visual Basic). After you mark the methods as static, the compiler will emit nonvirtual call sites to these members. Emitting nonvirtual call sites will prevent a check at runtime for each call that makes sure that the current object pointer is non-null. This can achieve a measurable performance gain for performance-sensitive code. In some cases, the failure to access the current object instance represents a correctness issue.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Mark the member as static (or Shared in Visual Basic) or use 'this'/'Me' in the method body, if appropriate.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule for previously shipped code for which the fix would be a breaking change.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:AvoidUncalledPrivateCode}<br/>
+
+
+
+
+                {rule:fxcop:AvoidUninstantiatedInternalClasses}<br/>
+
+
+
+
+                {rule:fxcop:RemoveUnusedLocals}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms245046.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms245046.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AvoidUnusedPrivateFields">
+    <configKey>CA1823</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1823: Avoid unused private fields]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            This rule is reported when a private field in your code exists but is not used by any code path.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Private fields were detected that do not appear to be accessed in the assembly.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, remove the field or add code that uses it.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:AvoidUninstantiatedInternalClasses}<br/>
+
+
+
+
+                {rule:fxcop:ReviewUnusedParameters}<br/>
+
+
+
+
+                {rule:fxcop:RemoveUnusedLocals}<br/>
+
+
+
+
+                {rule:fxcop:AvoidUncalledPrivateCode}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms245042.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms245042.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="MarkAssembliesWithNeutralResourcesLanguage">
+    <configKey>CA1824</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1824: Mark assemblies with NeutralResourcesLanguageAttribute]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An assembly contains a ResX-based resource but does not have the <code>System.Resources.NeutralResourcesLanguageAttribute</code> applied to it.
+</p>
+<h2>Rule Description</h2>
+<p>
+            The NeutralResourcesLanguage attribute informs the ResourceManager of the language that was used to display the resources of the neutral culture for an assembly. When it looks up resources in the same culture as the neutral resources language, the ResourceManager automatically uses the resources that are located in the main assembly. It does this instead of searching for a satellite assembly that has the current user interface culture for the current thread. This improves lookup performance for the first resource that you load and can reduce your working set.
+</p>
+<h2>Fixing Violations</h2>
+<p>
+            To fix a violation of this rule, add the attribute to the assembly, and specify the language of the resources of the neutral culture.
+</p>
+<h2>Specifying the Language</h2>
+<p>
+            To specify the language of the resource of the neutral culture
+
+
+                <li>
+                  In Solution Explorer, right-click your project, and then Click Properties.
+                </li>
+                <li>
+                  From the left navigation bar select Application, and then click Assembly Information.
+                </li>
+                <li>
+                  In the Assembly Information dialog box, select the language from the Neutral Language drop-down list.
+                </li>
+                <li>
+                  Click OK.
+                </li>
+
+
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is permissible to suppress a warning from this rule. However, startup performance might decrease.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb385967.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb385967.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ValueTypeFieldsShouldBePortable">
+    <configKey>CA1900</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1900: Value type fields should be portable]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            This rule checks that structures that are declared with explicit layout will align correctly when marshaled to unmanaged code on 64-bit operating systems. IA-64 does not allow unaligned memory accesses and the process will crash if this violation is not fixed.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Structures that have explicit layout that contains misaligned fields cause crashes on 64-bit operating systems.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            All fields that are smaller than 8 bytes must have offsets that are a multiple of their size, and fields that are 8 bytes or more must have offsets that are a multiple of 8. Another solution is to use <code>LayoutKind.Sequential</code> instead of <code>LayoutKind.Explicit</code>, if reasonable.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            This warning should be suppressed only if it occurs in error.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182285.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182285.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="PInvokeDeclarationsShouldBePortable">
+    <configKey>CA1901</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1901: P/Invoke declarations should be portable]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            This rule evaluates the size of each parameter and the return value of a P/Invoke and verifies that their size, when marshaled to unmanaged code on 32-bit and 64-bit platforms, is correct. The most common violation of this rule is to pass a fixed-sized integer where a platform-dependent, pointer-sized variable is required.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Either of the following scenarios violates this rule occurs:
+            <ul>
+              <li>
+                The return value or parameter is typed as a fixed-size integer when it should be typed as an <code>IntPtr</code>.
+              </li>
+              <li>
+                The return value or parameter is typed as an <code>IntPtr</code> when it should be typed as a fixed-size integer.
+              </li>
+            </ul>
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            You can fix this violation by using <code>IntPtr</code> or <code>UIntPtr</code> to represent handles instead of <code>Int32</code> or <code>UInt32</code>.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            You should not suppress this warning.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182284.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182284.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="UseOnlyApiFromTargetedFramework">
+    <configKey>CA1903</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA1903: Use only API from targeted framework]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A member or type is using a member or type that was introduced in a service pack that was not included with the project's targeted framework.
+</p>
+<h2>Rule Description</h2>
+<p>
+            New members and types were included in .NET Framework 2.0 Service Pack 1 and 2, .NET Framework 3.0 Service Pack 1 and 2, and .NET Framework 3.5 Service Pack 1. Projects that target the major versions of the .NET Framework can unintentionally take dependencies on these new APIs. To prevent this dependency, this rule fires on usages of any new members and types that were not included by default with the project's target framework.
+
+              Target Framework and Service Pack Dependencies
+
+
+
+
+
+
+
+
+                    When target framework is
+
+
+                    Fires on usages of members introduced in
+
+
+
+
+                    .NET Framework 2.0
+
+
+                    .NET Framework 2.0 SP1, .NET Framework 2.0 SP2
+
+
+
+
+                    .NET Framework 3.0
+
+
+                    .NET Framework 2.0 SP1, .NET Framework 2.0 SP2, .NET Framework 3.0 SP1, .NET Framework 3.0 SP2
+
+
+
+
+                    .NET Framework 3.5
+
+
+                    .NET Framework 3.5 SP1
+
+
+
+
+                    .NET Framework 4
+
+
+                    N/A
+
+
+
+
+            To change a project's target framework, see Targeting a Specific .NET Framework Version or Profile.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To remove the dependency on the service pack, remove all usages of the new member or type. If this is a deliberate dependency, either suppress the warning or turn this rule off.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule if this was not a deliberate dependency on the specified service pack. In this situation, your application might fail to run on systems without this service pack installed. Suppress the warning or turn this rule off if this was a deliberate dependency.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/cc667408.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/cc667408.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DisposeObjectsBeforeLosingScope">
+    <configKey>CA2000</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2000: Dispose objects before losing scope]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A local object of a <code>IDisposable</code> type is created but the object is not disposed before all references to the object are out of scope.
+</p>
+<h2>Rule Description</h2>
+<p>
+            If a disposable object is not explicitly disposed before all references to it are out of scope, the object will be disposed at some indeterminate time when the garbage collector runs the finalizer of the object. Because an exceptional event might occur that will prevent the finalizer of the object from running, the object should be explicitly disposed instead.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, call <code>Dispose</code> on the object before all references to it are out of scope.
+            Note that you can use the <code>using</code> statement (<code>Using</code> in Visual Basic) to wrap objects that implement <code>IDisposable</code>. Objects that are wrapped in this manner will automatically be disposed at the close of the <code>using</code> block.
+            The following are some situations where the using statement is not enough to protect IDisposable objects and can cause CA2000 to occur.
+            <ul>
+              <li>
+                Returning a disposable object requires that the object is constructed in a try/finally block outside a using block.
+              </li>
+              <li>
+                Initializing members of a disposable object should not be done in the constructor of a using statement.
+              </li>
+              <li>
+                Nesting constructors that are protected only by one exception handler. For example,
+
+
+
+
+
+
+
+
+
+            <pre>
+using (StreamReader sr = new StreamReader(new FileStream("C:\myfile.txt", FileMode.Create)))
+{ ... }
+</pre>
+
+
+
+
+causes CA2000 to occur because a failure in the construction of the StreamReader object can result in the FileStream object never being closed.</li>
+              <li>
+                Dynamic objects should use a shadow object to implement the Dispose pattern of IDisposable objects.
+              </li>
+            </ul>
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule unless you have called a method on your object that calls <code>Dispose</code>, such as <code>Close</code>, or if the method that raised the warning returns an IDisposable object wraps your object.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:DisposableFieldsShouldBeDisposed}<br/>
+
+
+
+
+                {rule:fxcop:DoNotDisposeObjectsMultipleTimes}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182289.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182289.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AvoidCallingProblematicMethods">
+    <configKey>CA2001</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2001: Avoid calling problematic methods]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A member calls a potentially dangerous or problematic method.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Avoid making unnecessary and potentially dangerous method calls.
+            A violation of this rule occurs when a member calls one of the following methods.
+
+
+
+
+
+
+
+                    Method
+
+
+                    Description
+
+
+
+
+
+
+                        <code>GC.Collect</code>
+
+
+
+
+                    Calling GC.Collect can significantly affect application performance and is rarely necessary. For more information, see the Rico Mariani's Performance Tidbits blog entry on MSDN.
+
+
+
+
+
+
+                        <code>Thread.Resume</code>
+
+
+
+
+                        <code>Thread.Suspend</code>
+
+
+
+
+                    Thread.Suspend and Thread.Resume have been deprecated because of their unpredictable behavior.  Use other classes in the <code>System.Threading</code> namespace, such as <code>Monitor</code>, [T:System.Threading.Mutex,] <code>Mutex</code>, and <code>Semaphore</code> to synchronize threads or protect resources.
+
+
+
+
+
+
+                        <code>SafeHandle.DangerousGetHandle</code>
+
+
+
+
+                    The DangerousGetHandle method poses a security risk because it can return a handle that is not valid. See the <code>DangerousAddRef</code>  and the <code>DangerousRelease</code> methods for more information about how to use the DangerousGetHandle method safely.
+
+
+
+
+
+
+                        <code>Assembly.LoadFrom</code>
+
+
+
+
+                        <code>Assembly.LoadFile</code>
+
+
+
+
+                        <code>Assembly.LoadWithPartialName</code>
+
+
+
+
+                    These methods can load assemblies from unexpected locations. For example, see Suzanne Cook's .NET CLR Notes blog posts LoadFile vs. LoadFrom and Choosing a Binding Context on the MSDN Web site for information about methods that load assemblies.
+
+
+
+
+
+                      CoSetProxyBlanket (Ole32)
+
+                      CoInitializeSecurity (Ole32)
+
+
+                    By the time the user code starts executing in a managed process, it is too late to reliably call CoSetProxyBlanket. The common language runtime (CLR) takes initialization actions that may prevent the users P/Invoke from succeeding.
+                    If you do have to call CoSetProxyBlanket for a managed application, we recommend that you start the process by using a native code (C++) executable, call CoSetProxyBlanket in the native code, and then start your managed code application in process. (Be sure to specify a runtime version number.)
+
+
+
+
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, remove or replace the call to the dangerous or problematic method.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            You should suppress messages from this rule only when no alternatives to the problematic method are available.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb385973.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb385973.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotLockOnObjectsWithWeakIdentity">
+    <configKey>CA2002</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2002: Do not lock on objects with weak identity]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A thread attempts to acquire a lock on an object that has a weak identity.
+</p>
+<h2>Rule Description</h2>
+<p>
+            An object is said to have a weak identity when it can be directly accessed across application domain boundaries. A thread that tries to acquire a lock on an object that has a weak identity can be blocked by a second thread in a different application domain that has a lock on the same object. The following types have a weak identity and are flagged by the rule:
+            <ul>
+              <li>
+
+
+                    <code>MarshalByRefObject</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>ExecutionEngineException</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>OutOfMemoryException</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>StackOverflowException</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>String</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>MemberInfo</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>ParameterInfo</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>Thread</code>
+
+
+              </li>
+            </ul>
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, use an object from a type that is not in the list in the Description section.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:DisposableFieldsShouldBeDisposed}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182290.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182290.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotTreatFibersAsThreads">
+    <configKey>CA2003</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2003: Do not treat fibers as threads]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A managed thread is being treated as a Win32 thread.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Do not assume a managed thread is a Win32 thread. It is a fiber. The common language runtime (CLR) will run managed threads as fibers in the context of real threads that are owned by SQL. These threads can be shared across AppDomains and even databases in the SQL Server process. Using managed thread local storage will work, but you may not use unmanaged thread local storage or assume that your code will run on the current OS thread again. Do not change settings such as the locale of the thread. Do not call CreateCriticalSection or CreateMutex via P/Invoke because they require that the thread that enters a lock must also exit the lock. Because this will not be the case when you use fibers, Win32 critical sections and mutexes will be useless in SQL. You may safely use most of the state on a managed System.Thread object. This includes managed thread local storage and the current user interface (UI) culture of the thread. However, for programming model reasons, you will not be able to change the current culture of a thread when you  use SQL; this will be enforced through a new permission.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Examine your usage of threads and change your code accordingly.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            You should not suppress this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182291.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182291.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="RemoveCallsToGCKeepAlive">
+    <configKey>CA2004</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2004: Remove calls to GC.KeepAlive]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            Classes use <code>SafeHandle</code> but still contain calls to <code>GC.KeepAlive</code>.
+</p>
+<h2>Rule Description</h2>
+<p>
+            If you are converting to <code>SafeHandle</code> usage, remove all calls to <code>GC.KeepAlive </code>(object). In this case, classes should not have to call <code>GC.KeepAlive</code>,<code> </code>assuming they do not have a finalizer but rely on <code>SafeHandle</code> to complete the OS handle for them.  Although the cost of leaving in a call to <code>GC.KeepAlive</code> might be negligible as measured by performance, the perception that a call to <code>GC.KeepAlive</code> is either necessary or sufficient to solve a lifetime issue that might no longer exist makes the code harder to maintain.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Remove calls to <code>GC.KeepAlive</code>.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            You can suppress this warning only if it is not technically correct to convert to <code>SafeHandle</code> usage in your class.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182293.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182293.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="UseSafeHandleToEncapsulateNativeResources">
+    <configKey>CA2006</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2006: Use SafeHandle to encapsulate native resources]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            Managed code uses <code>IntPtr</code> to access native resources.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Use of <code>IntPtr</code> in managed code might indicate a potential security and reliability problem. All uses of <code>IntPtr</code> must be reviewed to determine whether the use of a <code>SafeHandle</code> , or a similar technology, is required in its place. Problems will occur if the <code>IntPtr</code> represents some native resource, such as memory, a file handle, or a socket, that the managed code is considered to own. If the managed code owns the resource, it must also release the native resources associated with it, because a failure to do so would cause resource leakage.
+            In such scenarios, security or reliability problems will also exist if multithreaded access is allowed to the <code>IntPtr</code> and a way of releasing the resource that is represented by the <code>IntPtr</code> is provided. These problems involve recycling of the <code>IntPtr</code> value on resource release while simultaneous use of the resource is being made on another thread. This can cause race conditions where one thread can read or write data that is associated with the wrong resource. For example, if your type stores an OS handle as an <code>IntPtr</code> and allows users to call both Close and any other method that uses that handle simultaneously and without some kind of synchronization, your code has a handle recycling problem.
+            This handle recycling problem can cause data corruption and, frequently, a security vulnerability. <code>SafeHandle</code> and its sibling class <code>CriticalHandle</code> provide a mechanism to encapsulate a native handle to a resource so that such threading problems can be avoided. Additionally, you can use <code>SafeHandle</code> and its sibling class <code>CriticalHandle</code> for other threading issues, for example, to carefully control the lifetime of managed objects that contain a copy of the native handle over calls to native methods. In this situation, you can often remove calls to <code>GC.KeepAlive</code>. The performance overhead thay you incur when you use <code>SafeHandle</code> and, to a lesser degree, <code>CriticalHandle</code>, can frequently be reduced through careful design.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Convert <code>IntPtr</code> usage to <code>SafeHandle</code> to safely manage access to native resources. See the <code>SafeHandle</code> reference topic for examples.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            You should not suppress this warning.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182294.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182294.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ReviewSqlQueriesForSecurityVulnerabilities">
+    <configKey>CA2100</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2100: Review SQL queries for security vulnerabilities]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method sets the <code>IDbCommand.CommandText</code> property by using a string that is built from a string argument to the method.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule assumes that the string argument contains user input. A SQL command string that is built from user input is vulnerable to SQL injection attacks. In a SQL injection attack, a malicious user supplies input that alters the design of a query in an attempt to damage or gain unauthorized access to the underlying database. Typical techniques include injection of a single quotation mark or apostrophe, which is the SQL literal string delimiter; two dashes, which signifies a SQL comment; and a semicolon, which indicates that a new command follows. If user input must be part of the query, use one of the following, listed in order of effectiveness, to reduce the risk of attack.
+            <ul>
+              <li>
+                Use a stored procedure.
+              </li>
+              <li>
+                Use a parameterized command string.
+              </li>
+              <li>
+                Validate the user input for both type and content before you build the command string.
+              </li>
+            </ul>
+            The following .NET Framework types implement the <code>CommandText</code> property or provide constructors that set the property by using a string argument.
+            <ul>
+              <li>
+
+
+                    <code>System.Data.Odbc.OdbcCommand</code>
+                   and <code>System.Data.Odbc.OdbcDataAdapter</code>
+              </li>
+              <li>
+
+
+                    <code>System.Data.OleDb.OleDbCommand</code>
+                   and <code>System.Data.OleDb.OleDbDataAdapter</code>
+              </li>
+              <li>
+
+
+                    <code>System.Data.OracleClient.OracleCommand</code>
+                   and <code>System.Data.OracleClient.OracleDataAdapter</code>
+              </li>
+              <li>
+
+                  [System.Data.SqlServerCe.SqlCeCommand] and  [System.Data.SqlServerCe.SqlCeDataAdapter]
+              </li>
+              <li>
+
+
+                    <code>System.Data.SqlClient.SqlCommand</code>
+                   and <code>System.Data.SqlClient.SqlDataAdapter</code>
+              </li>
+            </ul>
+            Notice that this rule is violated when the ToString method of a type is used explicitly or implicitly to construct the query string. The following is an example.
+
+
+
+
+
+
+
+
+
+            <pre>
+int x = 10;
+string query = "SELECT TOP " + x.ToString() + " FROM Table";
+</pre>
+
+
+
+
+The rule is violated because a malicious user can override the ToString() method.The rule also is violated when ToString is used implicitly.
+
+
+
+
+
+
+
+
+
+            <pre>
+int x = 10;
+string query = String.Format("SELECT TOP {0} FROM Table", x);
+</pre>
+
+
+
+
+
+
+
+
+
+
+
+                How to Fix Violations
+
+
+
+
+
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if the command text does not contain any user input.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182310.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182310.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="SpecifyMarshalingForPInvokeStringArguments">
+    <configKey>CA2101</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2101: Specify marshaling for P/Invoke string arguments]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A platform invoke member allows for partially trusted callers, has a string parameter, and does not explicitly marshal the string.
+</p>
+<h2>Rule Description</h2>
+<p>
+            When you convert from Unicode to ANSI, it is possible that not all Unicode characters can be represented in a specific ANSI code page. Best-fit mapping tries to solve this problem by substituting a character for the character that cannot be represented. The use of this feature can cause a potential security vulnerability because you cannot control the character that is chosen. For example, malicious code could intentionally create a Unicode string that contains characters that are not found in a particular code page, which are converted to file system special characters such as '..' or '/'. Note also that security checks for special characters frequently occur before the string is converted to ANSI.
+            Best-fit mapping is the default for the unmanaged conversion, WChar to MByte. Unless you explicitly disable best-fit mapping, your code might contain an exploitable security vulnerability because of this issue.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, explicitly marshal string data types.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182319.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182319.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="CatchNonClsCompliantExceptionsInGeneralHandlers">
+    <configKey>CA2102</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2102: Catch non-CLSCompliant exceptions in general handlers]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A member in an assembly that is not marked with the <code>RuntimeCompatibilityAttribute</code> or is marked RuntimeCompatibility(WrapNonExceptionThrows = false) contains a catch block that handles <code>System.Exception</code> and does not contain an immediately following general catch block. This rule ignores Visual Basic assemblies.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A catch block that handles <code>Exception</code> catches all Common Language Specification (CLS) compliant exceptions. However, it does not catch non-CLS compliant exceptions. Non-CLS compliant exceptions can be thrown from native code or from managed code that was generated by the Microsoft intermediate language (MSIL) Assembler. Notice that the C# and Visual Basic compilers do not allow non-CLS compliant exceptions to be thrown and Visual Basic does not catch non-CLS compliant exceptions. If the intent of the catch block is to handle all exceptions, use the following general catch block syntax.
+            <ul>
+              <li>
+                C#: catch {}
+              </li>
+              <li>
+                C++: catch(...) {} or catch(Object^) {}
+              </li>
+            </ul>
+            An unhandled non-CLS compliant exception becomes a security issue when previously allowed permissions are removed in the catch block. Because non-CLS compliant exceptions are not caught, a malicious method that throws a non-CLS compliant exception could run with elevated permissions.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule when the intent is to catch all exceptions, substitute or add a general catch block or mark the assembly RuntimeCompatibility(WrapNonExceptionThrows = true). If permissions are removed in the catch block, duplicate the functionality in the general catch block. If it is not the intent to handle all exceptions, replace the catch block that handles <code>Exception</code> with catch blocks that handle specific exception types.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if the try block does not contain any statements that might generate a non-CLS compliant exception. Because any native or managed code might throw a non-CLS compliant exception, this requires knowledge of all code that can be executed in all code paths inside the try block. Notice that non-CLS compliant exceptions are not thrown by the common language runtime.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:DoNotCatchGeneralExceptionTypes}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb264489.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb264489.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ReviewImperativeSecurity">
+    <configKey>CA2103</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2103: Review imperative security]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method uses imperative security and might be constructing the permission by using state information or return values that can change as long as the demand is active.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Imperative security uses managed objects to specify permissions and security actions during code execution, compared to declarative security, which uses attributes to store permissions and actions in metadata. Imperative security is very flexible because you can set the state of a permission object and select security actions by using information that is not available until run time. Together with that flexibility comes the risk that the runtime information that you use to determine the state of a permission does not remain unchanged as long as the action is in effect.
+            Use declarative security whenever possible. Declarative demands are easier to understand.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Review the imperative security demands to make sure that the state of the permission does not rely on information that can change as long as the permission is being used.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if the permission does not rely on changing data. However, it is better to change the imperative demand to its declarative equivalent.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182309.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182309.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotDeclareReadOnlyMutableReferenceTypes">
+    <configKey>CA2104</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2104: Do not declare read only mutable reference types]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An externally visible type contains an externally visible read-only field that is a mutable reference type.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A mutable type is a type whose instance data can be modified. The <code>System.Text.StringBuilder</code> class is an example of a mutable reference type. It contains members that can change the value of an instance of the class. An example of an immutable reference type is the <code>System.String</code> class. After it has been instantiated, its value can never change.
+            The read-only modifier (readonly (C# Reference) in C#, ReadOnly (Visual Basic) in Visual Basic, and <code>const (C++)</code> in C++) on a reference type field (pointer in C++) prevents the field from being replaced by a different instance of the reference type. However, the modifier does not prevent the instance data of the field from being modified through the reference type.
+            Read-only array fields are exempt from this rule but instead cause a violation of the {rule:fxcop:ArrayFieldsShouldNotBeReadOnly} rule.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, remove the read-only modifier or, if a breaking change is acceptable, replace the field with an immutable type.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if the field type is immutable.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182302.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182302.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ArrayFieldsShouldNotBeReadOnly">
+    <configKey>CA2105</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2105: Array fields should not be read only]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected field that holds an array is declared read-only.
+</p>
+<h2>Rule Description</h2>
+<p>
+            When you apply the <code>readonly</code> (<code>ReadOnly</code> in Visual Basic) modifier to a field that contains an array, the field cannot be changed to refer to a different array. However, the elements of the array that are stored in a read-only field can be changed. Code that makes decisions or performs operations that are based on the elements of a read-only array that can be publicly accessed might contain an exploitable security vulnerability.
+            Note that having a public field also violates the design rule {rule:fxcop:DoNotDeclareVisibleInstanceFields}.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix the security vulnerability that is identified by this rule, do not rely on the contents of a read-only array that can be publicly accessed. It is strongly recommended that you use one of the following procedures:
+            <ul>
+              <li>
+                Replace the array with a strongly typed collection that cannot be changed. For more information, see <code>System.Collections.ReadOnlyCollectionBase</code>.
+              </li>
+              <li>
+                Replace the public field with a method that returns a clone of a private array. Because your code does not rely on the clone, there is no danger if the elements are modified.
+              </li>
+            </ul>
+            If you chose the second approach, do not replace the field with a property; properties that return arrays adversely affect performance. For more information, see <code>CA1819: Properties should not return arrays</code>.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Exclusion of a warning from this rule is strongly discouraged. Almost no scenarios occur where the contents of a read-only field are unimportant. If this is the case with your scenario, remove the <code>readonly</code> modifier instead of excluding the message.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182299.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182299.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="SecureAsserts">
+    <configKey>CA2106</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2106: Secure asserts]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method asserts a permission and no security checks are performed on the caller.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Asserting a security permission without performing any security checks can leave an exploitable security weakness in your code. A security stack walk stops when a security permission is asserted. If you assert a permission without performing any checks on the caller, the caller could indirectly execute code by using your permissions. Asserts without security checks are permissible only when you are sure that the assert cannot be used in a harmful manner. An assert is harmless if the code you call is harmless, or users cannot pass arbitrary information to code that you call.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, add a security demand to the method or its declaring type.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Suppress a warning from this rule only after a careful security review.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182314.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182314.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ReviewDenyAndPermitOnlyUsage">
+    <configKey>CA2107</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2107: Review deny and permit only usage]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method contains a security check that specifies the PermitOnly or Deny security action.
+</p>
+<h2>Rule Description</h2>
+<p>
+            The Using the PermitOnly Method and <code>CodeAccessPermission.Deny</code> security actions should be used only by those who have an advanced knowledge of .NET Framework security. Code that uses these security actions should undergo a security review.
+            Deny alters the default behavior of the stack walk that occurs in response to a security demand. It lets you specify permissions that must not be granted for the duration of the denying method, regardless of the actual permissions of the callers in the call stack. If the stack walk detects a method that is secured by Deny, and if the demanded permission is included in the denied permissions, the stack walk fails. PermitOnly also alters the default behavior of the stack walk. It allows code to specify only those permissions that can be granted, regardless of the permissions of the callers. If the stack walk detects a method that is secured by PermitOnly, and if the demanded permission is not included in the permissions that are specified by the PermitOnly, the stack walk fails.
+            Code that relies on these actions should be carefully evaluated for security vulnerabilities because of their limited usefulness and subtle behavior. Consider the following:
+            <ul>
+              <li>
+
+
+                    Link Demands
+                   are not affected by Deny or PermitOnly.
+              </li>
+              <li>
+                If the Deny or PermitOnly occurs in the same stack frame as the demand that causes the stack walk, the security actions have no effect.
+              </li>
+              <li>
+                Values that are used to construct path-based permissions can usually be specified in multiple ways. Denying access to one form of the path does not deny access to all forms. For example, if a file share \\Server\Share is mapped to a network drive X:, to deny access to a file on the share, you must deny \\Server\Share\File, X:\File and every other path that accesses the file.
+              </li>
+              <li>
+                An <code>CodeAccessPermission.Assert</code> can terminate a stack walk before the Deny or PermitOnly is reached.
+              </li>
+              <li>
+                If a Deny has any effect, namely, when a caller has a permission that is blocked by the Deny, the caller can access the protected resource directly, bypassing the Deny. Similarly, if the caller does not have the denied permission, the stack walk would fail without the Deny.
+              </li>
+            </ul>
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Any use of these security actions will cause a violation. To fix a violation, do not use these security actions.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Suppress a warning from this rule only after you complete a security review.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182308.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182308.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ReviewDeclarativeSecurityOnValueTypes">
+    <configKey>CA2108</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2108: Review declarative security on value types]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected value type is secured by a <code>Data and Modeling in the .NET Framework</code> or Link Demands.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Value types are allocated and initialized by their default constructors before other constructors execute. If a value type is secured by a Demand or LinkDemand, and the caller does not have permissions that satisfy the security check, any constructor other than the default will fail, and a security exception will be thrown. The value type is not deallocated; it is left in the state set by its default constructor. Do not assume that a caller that passes an instance of the value type has permission to create or access the instance.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            You cannot fix a violation of this rule unless you remove the security check from the type, and use method level security checks in its place. Note that fixing the violation in this manner will not prevent callers with inadequate permissions from obtaining instances of the value type. You must ensure that an instance of the value type, in its default state, does not expose sensitive information, and cannot be used in a harmful manner.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            You can suppress a warning from this rule if any caller can obtain instances of the value type in its default state without posing a threat to security.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182307.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182307.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ReviewVisibleEventHandlers">
+    <configKey>CA2109</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2109: Review visible event handlers]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected event-handling method was detected.
+</p>
+<h2>Rule Description</h2>
+<p>
+            An externally visible event-handling method presents a security issue that requires review.
+            Event-handling methods should not be exposed unless absolutely necessary. An event handler, a delegate type, that invokes the exposed method can be added to any event as long as the handler and event signatures match. Events can potentially be raised by any code, and are frequently raised by highly trusted system code in response to user actions such as clicking a button. Adding a security check to an event-handling method does not prevent code from registering an event handler that invokes the method.
+            A demand cannot reliably protect a method invoked by an event handler. Security demands help protect code from untrusted callers by examining the callers on the call stack. Code that adds an event handler to an event is not necessarily present on the call stack when the event handler's methods run. Therefore, the call stack might have only highly trusted callers when the event handler method is invoked. This causes demands made by the event handler method to succeed. Also, the demanded permission might be asserted when the method is invoked. For these reasons, the risk of not fixing a violation of this rule can only be assessed after reviewing the event-handling method. When you review your code, consider the following issues:
+            <ul>
+              <li>
+                Does your event handler perform any operations that are dangerous or exploitable, such as asserting permissions or suppressing unmanaged code permission?
+              </li>
+              <li>
+                What are the security threats to and from your code because it can run at any time with only highly trusted callers on the stack?
+              </li>
+            </ul>
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, review the method and evaluate the following:
+            <ul>
+              <li>
+                Can you make the event-handling method non-public?
+              </li>
+              <li>
+                Can you move all dangerous functionality out of the event handler?
+              </li>
+              <li>
+                If a security demand is imposed, can this be accomplished in some other manner?
+              </li>
+            </ul>
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Suppress a warning from this rule only after a careful security review to make sure that your code does not pose a security threat.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182312.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182312.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="PointersShouldNotBeVisible">
+    <configKey>CA2111</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2111: Pointers should not be visible]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected <code>System.IntPtr</code> or <code>System.UIntPtr</code> field is not read-only.
+</p>
+<h2>Rule Description</h2>
+<p>
+
+
+                <code>IntPtr</code>
+               and <code>UIntPtr</code> are pointer types that are used to access unmanaged memory. If a pointer is not private, internal, or read-only, malicious code can change the value of the pointer, potentially allowing access to arbitrary locations in memory or causing application or system failures.
+            If you intend to secure access to the type that contains the pointer field, see {rule:fxcop:SecuredTypesShouldNotExposeFields}.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Secure the pointer by making it read-only, internal, or private.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Suppress a warning from this rule if you do not rely on the value of the pointer.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:SecuredTypesShouldNotExposeFields}<br/>
+
+
+
+
+                {rule:fxcop:DoNotDeclareVisibleInstanceFields}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182306.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182306.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="SecuredTypesShouldNotExposeFields">
+    <configKey>CA2112</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2112: Secured types should not expose fields]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected type contains public fields and is secured by a Link Demands.
+</p>
+<h2>Rule Description</h2>
+<p>
+            If code has access to an instance of a type that is secured by a link demand, the code does not have to satisfy the link demand to access the type's fields.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, make the fields nonpublic and add public properties or methods that return the field data. LinkDemand security checks on types protect access to the type's properties and methods. However, code access security does not apply to fields.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Both for security issues and for good design, you should fix violations by making the public fields nonpublic. You can suppress a warning from this rule if the field does not hold information that should remain secured, and you do not rely on the contents of the field.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:DoNotDeclareVisibleInstanceFields}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182318.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182318.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="MethodSecurityShouldBeASupersetOfType">
+    <configKey>CA2114</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2114: Method security should be a superset of type]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type has declarative security and one of its methods has declarative security for the same security action, and the security action is not Link Demands or Inheritance Demands, and the permissions checked by the type are not a subset of the permissions checked by the method.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A method should not have both a method-level and type-level declarative security for the same action. The two checks are not combined; only the method-level demand is applied. For example, if a type demands permission X, and one of its methods demands permission Y, code does not have to have permission X to execute the method.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Review your code to make sure that both actions are required. If both actions are required, make sure that the method-level action includes the security specified at the type level. For example, if your type demands permission X, and its method must also demand permission Y, the method should explicitly demand X and Y.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if the method does not require the security specified by the type. However, this is not an ordinary scenario and might indicate a need for a careful design review.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182304.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182304.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="CallGCKeepAliveWhenUsingNativeResources">
+    <configKey>CA2115</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2115: Call GC.KeepAlive when using native resources]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method declared in a type with a finalizer references a <code>System.IntPtr</code> or <code>System.UIntPtr</code> field, but does not call <code>GC.KeepAlive</code>.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Garbage collection finalizes an object if there are no more references to it in managed code. Unmanaged references to objects do not prevent garbage collection. This rule detects errors that might occur because an unmanaged resource is being finalized while it is still being used in unmanaged code.
+            This rule assumes that <code>IntPtr</code> and <code>UIntPtr</code> fields store pointers to unmanaged resources. Because the purpose of a finalizer is to free unmanaged resources, the rule assumes that the finalizer will free the unmanaged resource pointed to by the pointer fields. This rule also assumes that the method is referencing the pointer field to pass the unmanaged resource to unmanaged code.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, add a call to <code>KeepAlive</code> to the method, passing the current instance (<code>this</code> in C# and C++) as the argument. Position the call after the last line of code where the object must be protected from garbage collection. Immediately after the call to <code>KeepAlive</code>, the object is again considered ready for garbage collection assuming that there are no managed references to it.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            This rule makes some assumptions that can lead to false positives. You can safely suppress a warning from this rule if:
+            <ul>
+              <li>
+                The finalizer does not free the contents of the <code>IntPtr</code> or <code>UIntPtr</code> field referenced by the method.
+              </li>
+              <li>
+                The method does not pass the <code>IntPtr</code> or <code>UIntPtr</code> field to unmanaged code.
+              </li>
+            </ul>
+            Carefully review other messages before excluding them. This rule detects errors that are difficult to reproduce and debug.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182300.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182300.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AptcaMethodsShouldOnlyCallAptcaMethods">
+    <configKey>CA2116</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2116: APTCA methods should only call APTCA methods]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method in an assembly with the <code>System.Security.AllowPartiallyTrustedCallersAttribute</code> attribute calls a method in an assembly that does not have the attribute.
+</p>
+<h2>Rule Description</h2>
+<p>
+            By default, public or protected methods in assemblies with strong names are implicitly protected by a Link Demands for full trust; only fully trusted callers can access a strong-named assembly. Strong-named assemblies marked with the <code>AllowPartiallyTrustedCallersAttribute</code> (APTCA) attribute do not have this protection. The attribute disables the link demand, making the assembly accessible to callers that do not have full trust, such as code executing from an intranet or the Internet.
+            When the APTCA attribute is present on a fully trusted assembly, and the assembly executes code in another assembly that does not allow partially trusted callers, a security exploit is possible. If two methods M1 and M2 meet the following conditions, malicious callers can use the method M1 to bypass the implicit full trust link demand that protects M2:
+            <ul>
+              <li>
+
+                  M1 is a public method declared in a fully trusted assembly that has the APTCA attribute.
+              </li>
+              <li>
+
+                  M1 calls a method M2 outside M1's assembly.
+              </li>
+              <li>
+
+                  M2's assembly does not have the APTCA attribute and, therefore, should not be executed by or on behalf of callers that are partially trusted.
+              </li>
+            </ul>
+            A partially trusted caller X can call method M1, causing M1 to call M2. Because M2 does not have the APTCA attribute, its immediate caller (M1) must satisfy a link demand for full trust; M1 has full trust and therefore satisfies this check. The security risk is because X does not participate in satisfying the link demand that protects M2 from untrusted callers. Therefore, methods with the APTCA attribute must not call methods that do not have the attribute.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            If the APCTA attribute is required, use a demand to protect the method that calls into the full trust assembly. The exact permissions you demand will depend on the functionality exposed by your method. If it is possible, protect the method with a demand for full trust to ensure that the underlying functionality is not exposed to partially trusted callers. If this is not possible, select a set of permissions that effectively protects the exposed functionality. For more information about demands, see <code>Demands</code>.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            To safely suppress a warning from this rule, you must ensure that the functionality exposed by your method does not directly or indirectly allow callers to access sensitive information, operations, or resources that can be used in a destructive manner.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:AptcaTypesShouldOnlyExtendAptcaBaseTypes}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182297.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182297.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AptcaTypesShouldOnlyExtendAptcaBaseTypes">
+    <configKey>CA2117</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2117: APTCA types should only extend APTCA base types]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected type in an assembly with the <code>System.Security.AllowPartiallyTrustedCallersAttribute</code> attribute inherits from a type declared in an assembly that does not have the attribute.
+</p>
+<h2>Rule Description</h2>
+<p>
+            By default, public or protected types in assemblies with strong names are implicitly protected by an Inheritance Demands for full trust. Strong-named assemblies marked with the <code>AllowPartiallyTrustedCallersAttribute</code> (APTCA) attribute do not have this protection. The attribute disables the inheritance demand. This makes exposed types declared in the assembly inheritable by types that do not have full trust.
+            When the APTCA attribute is present on a fully trusted assembly, and a type in the assembly inherits from a type that does not allow partially trusted callers, a security exploit is possible. If two types T1 and T2 meet the following conditions, malicious callers can use the type T1 to bypass the implicit full trust inheritance demand that protects T2:
+            <ul>
+              <li>
+
+                  T1 is a public type declared in a fully trusted assembly that has the APTCA attribute.
+              </li>
+              <li>
+
+                  T1 inherits from a type T2 outside its assembly.
+              </li>
+              <li>
+
+                  T2's assembly does not have the APTCA attribute and, therefore, should not be inheritable by types in partially trusted assemblies.
+              </li>
+            </ul>
+            A partially trusted type X can inherit from T1, which gives it access to inherited members declared in T2. Because T2 does not have the APTCA attribute, its immediate derived type (T1) must satisfy an inheritance demand for full trust; T1 has full trust and therefore satisfies this check. The security risk is because X does not participate in satisfying the inheritance demand that protects T2 from untrusted subclassing. For this reason, types with the APTCA attribute must not extend types that do not have the attribute.
+            Another security issue, and perhaps a more common one, is that the derived type (T1) can, through programmer error, expose protected members from the type that requires full trust (T2). When this occurs, untrusted callers gain access to information that should be available only to fully trusted types.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            If the type reported by the violation is in an assembly that does not require the APTCA attribute, remove it.
+            If the APTCA attribute is required, add an inheritance demand for full trust to the type. This protects against inheritance by untrusted types.
+            It is possible to fix a violation by adding the APTCA attribute to the assemblies of the base types reported by the violation. Do not do this without first conducting an intensive security review of all code in the assemblies and all code that depends on the assemblies.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            To safely suppress a warning from this rule, you must ensure that protected members exposed by your type do not directly or indirectly allow untrusted callers to access sensitive information, operations, or resources that can be used in a destructive manner.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:AptcaMethodsShouldOnlyCallAptcaMethods}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182298.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182298.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ReviewSuppressUnmanagedCodeSecurityUsage">
+    <configKey>CA2118</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2118: Review SuppressUnmanagedCodeSecurityAttribute usage]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected type or member has the <code>System.Security.SuppressUnmanagedCodeSecurityAttribute</code> attribute.
+</p>
+<h2>Rule Description</h2>
+<p>
+
+
+                <code>SuppressUnmanagedCodeSecurityAttribute</code>
+               changes the default security system behavior for members that execute unmanaged code using COM interop or platform invocation. Generally, the system makes a <code>Data and Modeling in the .NET Framework</code> for unmanaged code permission. This demand occurs at run time for every invocation of the member, and checks every caller in the call stack for permission. When the attribute is present, the system makes a Link Demands for the permission: the permissions of the immediate caller are checked when the caller is JIT-compiled.
+            This attribute is primarily used to increase performance; however, the performance gains come with significant security risks. If you place the attribute on public members that call native methods, the callers in the call stack (other than the immediate caller) do not need unmanaged code permission to execute unmanaged code. Depending on the public member's actions and input handling, it might allow untrustworthy callers to access functionality normally restricted to trustworthy code.
+            The .NET Framework relies on security checks to prevent callers from gaining direct access to the current process's address space. Because this attribute bypasses normal security, your code poses a serious threat if it can be used to read or write to the process's memory. Note that the risk is not limited to methods that intentionally provide access to process memory; it is also present in any scenario where malicious code can achieve access by any means, for example, by providing surprising, malformed, or invalid input.
+            The default security policy does not grant unmanaged code permission to an assembly unless it is executing from the local computer or is a member of one of the following groups:
+            <ul>
+              <li>
+                My Computer Zone Code Group
+              </li>
+              <li>
+                Microsoft Strong Name Code Group
+              </li>
+              <li>
+                ECMA Strong Name Code Group
+              </li>
+            </ul>
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Carefully review your code to ensure that this attribute is absolutely necessary. If you are unfamiliar with managed code security, or do not understand the security implications of using this attribute, remove it from your code. If the attribute is required, you must ensure that callers cannot use your code maliciously. If your code does not have permission to execute unmanaged code, this attribute has no effect and should be removed.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            To safely suppress a warning from this rule, you must ensure that your code does not provide callers access to native operations or resources that can be used in a destructive manner.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182311.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182311.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="SealMethodsThatSatisfyPrivateInterfaces">
+    <configKey>CA2119</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2119: Seal methods that satisfy private interfaces]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An inheritable public type provides an overridable method implementation of an <code>internal</code> (<code>Friend</code> in Visual Basic) interface.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Interface methods have public accessibility, which cannot be changed by the implementing type. An internal interface creates a contract that is not intended to be implemented outside the assembly that defines the interface. A public type that implements a method of an internal interface using the <code>virtual</code> (<code>Overridable</code> in Visual Basic) modifier allows the method to be overridden by a derived type that is outside the assembly. If a second type in the defining assembly calls the method and expects an internal-only contract, behavior might be compromised when, instead, the overridden method in the outside assembly is executed. This creates a security vulnerability.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, prevent the method from being overridden outside the assembly by using one of the following:
+            <ul>
+              <li>
+                Make the declaring type <code>sealed</code> (<code>NotInheritable</code> in Visual Basic).
+              </li>
+              <li>
+                Change the accessibility of the declaring type to <code>internal</code> (<code>Friend</code> in Visual Basic).
+              </li>
+              <li>
+                Remove all public constructors from the declaring type.
+              </li>
+              <li>
+                Implement the method without using the <code>virtual</code> modifier.
+              </li>
+              <li>
+                Implement the method explicitly.
+              </li>
+            </ul>
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if, after careful review, no security issues exist that might be exploitable if the method is overridden outside the assembly.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182313.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182313.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="SecureSerializationConstructors">
+    <configKey>CA2120</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2120: Secure serialization constructors]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The type implements the <code>System.Runtime.Serialization.ISerializable</code> interface, is not a delegate or interface, and is declared in an assembly that allows partially trusted callers. The type has a constructor that takes a <code>System.Runtime.Serialization.SerializationInfo</code> object and a <code>System.Runtime.Serialization.StreamingContext</code> object (the signature of the serialization constructor). This constructor is not secured by a security check, but one or more of the regular constructors in the type is secured.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule is relevant for types that support custom serialization. A type supports custom serialization if it implements the <code>System.Runtime.Serialization.ISerializable</code> interface. The serialization constructor is required and is used to de-serialize, or re-create objects that have been serialized using the <code>ISerializable.GetObjectData</code> method. Because the serialization constructor allocates and initializes objects, security checks that are present on regular constructors must also be present on the serialization constructor. If you violate this rule, callers that could not otherwise create an instance could use the serialization constructor to do this.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, protect the serialization constructor with security demands that are identical to those protecting other constructors.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a violation of the rule.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:ImplementSerializationConstructors}<br/>
+
+
+
+
+                {rule:fxcop:MarkISerializableTypesWithSerializable}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182317.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182317.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="StaticConstructorsShouldBePrivate">
+    <configKey>CA2121</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2121: Static constructors should be private]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type has a static constructor that is not private.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A static constructor, also known as a class constructor, is used to initialize a type. The system calls the static constructor before the first instance of the type is created or any static members are referenced. The user has no control over when the static constructor is called. If a static constructor is not private, it can be called by code other than the system. Depending on the operations that are performed in the constructor, this can cause unexpected behavior.
+            This rule is enforced by the C# and Visual Basic .NET compilers.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Violations are typically caused by one of the following actions:
+            <ul>
+              <li>
+                You defined a static constructor for your type and did not make it private.
+              </li>
+              <li>
+                The programming language compiler added a default static constructor to your type and did not make it private.
+              </li>
+            </ul>
+            To fix the first kind of violation, make your static constructor private. To fix the second kind, add a private static constructor to your type.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress these violations. If your software design requires an explicit call to a static constructor, it is likely that the design contains serious flaws and should be reviewed.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182320.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182320.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotIndirectlyExposeMethodsWithLinkDemands">
+    <configKey>CA2122</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2122: Do not indirectly expose methods with link demands]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected member has a Link Demands and is called by a member that does not perform any security checks.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A link demand checks the permissions of the immediate caller only. If a member X makes no security demands of its callers, and calls code protected by a link demand, a caller without the necessary permission can use X to access the protected member.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Add a security <code>Data and Modeling in the .NET Framework</code> or link demand to the member so that it no longer provides unsecured access to the link demand-protected member.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            To safely suppress a warning from this rule, you must make sure that your code does not grant its callers access to operations or resources that can be used in a destructive manner.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182303.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182303.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="OverrideLinkDemandsShouldBeIdenticalToBase">
+    <configKey>CA2123</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2123: Override link demands should be identical to base]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected method in a public type overrides a method or implements an interface, and does not have the same Link Demands as the interface or virtual method.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule matches a method to its base method, which is either an interface or a virtual method in another type, and then compares the link demands on each. A violation is reported if either the method or the base method has a link demand and the other does not.
+            If this rule is violated, a malicious caller can bypass the link demand merely by calling the unsecured method.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, apply the same link demand to the overide method or implementation. If this is not possible, mark the method with a full demand or remove the attribute altogether.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182305.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182305.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="WrapVulnerableFinallyClausesInOuterTry">
+    <configKey>CA2124</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2124: Wrap vulnerable finally clauses in outer try]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            In versions 1.0 and 1.1 of the .NET Framework, a public or protected method contains a <code>try</code>/<code>catch</code>/<code>finally</code> block. The <code>finally</code> block appears to reset security state and is not enclosed in a <code>finally</code> block.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule locates <code>try</code>/<code>finally</code> blocks in code that targets versions 1.0 and 1.1 of the .NET Framework that might be vulnerable to malicious exception filters present in the call stack. If sensitive operations such as impersonation occur in the try block, and an exception is thrown, the filter can execute before the <code>finally</code> block. For the impersonation example, this means that the filter would execute as the impersonated user. Filters are currently implementable only in Visual Basic.
+
+
+
+
+
+                    Caution
+
+
+
+
+
+                      Note   In versions 2.0 and later of the .NET Framework, the runtime automatically protects a <code>try</code>/<code>catch</code>/ <code>finally</code> block from malicious exception filters, if the reset occurs directly within the method that contains the exception block.
+
+
+
+
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Place the unwrapped <code>try</code>/<code>finally</code> in an outer try block. See the second example that follows. This forces the <code>finally</code> to execute before filter code.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Pseudo-code Example</h2>
+
+<h3>Description</h3>
+<p>
+                The following pseudo-code illustrates the pattern detected by this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182322.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182322.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="TypeLinkDemandsRequireInheritanceDemands">
+    <configKey>CA2126</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2126: Type link demands require inheritance demands]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public unsealed type is protected with a link demand, has an overridable method, and neither the type nor the method is protected with an inheritance demand.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A link demand on a method or its declaring type requires the immediate caller of the method to have the specified permission. An inheritance demand on a method requires an overriding method to have the specified permission. An inheritance demand on a type requires a deriving class to have the specified permission.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, secure the type or the method with an inheritance demand for the same permission as the link demand.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:ReviewDeclarativeSecurityOnValueTypes}<br/>
+
+
+
+
+                {rule:fxcop:SecuredTypesShouldNotExposeFields}<br/>
+
+
+
+
+                {rule:fxcop:DoNotIndirectlyExposeMethodsWithLinkDemands}<br/>
+
+
+
+
+                {rule:fxcop:OverrideLinkDemandsShouldBeIdenticalToBase}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182321.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182321.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ConstantsShouldBeTransparent">
+    <configKey>CA2130</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2130: Security critical constants should be transparent]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A constant field or an enumeration member is marked with the <code>SecurityCriticalAttribute</code>.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Transparency enforcement is not enforced for constant values because compilers inline constant values so that no lookup is required at run time. Constant fields should be security transparent so that code reviewers do not assume that transparent code cannot access the constant.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, remove the SecurityCritical attribute from the field or value.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/dd997446.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/dd997446.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="CriticalTypesMustNotParticipateInTypeEquivalence">
+    <configKey>CA2131</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2131: Security critical types may not participate in type equivalence]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type participates in type equivalence and a either the type itself, or a member or field of the type, is marked with the <code>SecurityCriticalAttribute</code> attribute.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule fires on any critical types or types that contain critical methods or fields that are participating in type equivalence. When the CLR detects such a type, it fails to load it with a <code>TypeLoadException</code> at run time. Typically, this rule fires only when users implement type equivalence manually rather than by relying on tlbimp and the compilers to do the type equivalence.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, remove the SecurityCritical attribute.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/dd997564.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/dd997564.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DefaultConstructorsMustHaveConsistentTransparency">
+    <configKey>CA2132</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2132: Default constructors must be at least as critical as base type default constructors]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The transparency attribute of the default constructor of a derived class is not as critical as the transparency of the base class.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Types and members that have the <code>SecurityCriticalAttribute</code> cannot be used by Silverlight application code. Security-critical types and members can be used only by trusted code in the .NET Framework for Silverlight class library. Because a public or protected construction in a derived class must have the same or greater transparency than its base class, a class in an application cannot be derived from a class marked SecurityCritical.
+            For CoreCLR platform code, if a base type has a public or protected non-transparent default constructor then the derived type must obey the default constructor inheritance rules. The derived type must also have a default constructor and that constructor must be at least as critical default constructor of the base type.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix the violation, remove the type or do not derive from security non-transparent type.
+</p>
+<h2>When to Suppress Warnings</h2>
+
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+using System.Security;
+
+namespace TransparencyWarningsDemo
+{
+
+    public class BaseWithSafeCriticalDefaultCtor
+    {
+        [SecuritySafeCritical]
+        public BaseWithSafeCriticalDefaultCtor() { }
+    }
+
+    public class DerivedWithNoDefaultCtor : BaseWithSafeCriticalDefaultCtor
+    {
+        // CA2132 violation - since the base has a public or protected non-transparent default .ctor, the 
+        // derived type must also have a default .ctor
+    }
+
+    public class DerivedWithTransparentDefaultCtor : BaseWithSafeCriticalDefaultCtor
+    {
+        // CA2132 violation - since the base has a safe critical default .ctor, the derived type must have 
+        // either a safe critical or critical default .ctor.  This is fixed by making this .ctor safe critical 
+        // (however, user code cannot be safe critical, so this fix is platform code only).
+        DerivedWithTransparentDefaultCtor() { }
+    }
+
+    public class BaseWithCriticalCtor
+    {
+        [SecurityCritical]
+        public BaseWithCriticalCtor() { }
+    }
+
+    public class DerivedWithSafeCriticalDefaultCtor : BaseWithSafeCriticalDefaultCtor
+    {
+        // CA2132 violation - since the base has a critical default .ctor, the derived must also have a critical 
+        // default .ctor.  This is fixed by making this .ctor critical, which is not available to user code
+        [SecuritySafeCritical]
+        public DerivedWithSafeCriticalDefaultCtor() { }
+    }
+}
+</pre>
+
+
+
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/dd983956.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/dd983956.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DelegatesMustBindWithConsistentTransparency">
+    <configKey>CA2133</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2133: Delegates must bind to methods with consistent transparency]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            This warning fires on a method that binds a delegate that is marked with the <code>SecurityCriticalAttribute</code> to a method that is transparent or that is marked with the <code>SecuritySafeCriticalAttribute</code>. The warning also fires a method that binds a delegate that is transparent or safe-critical to a critical method.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Delegate types and the methods that they bind to must have consistent transparency. Transparent and safe-critical delegates may only bind to other transparent or safe-critical methods. Similarly, critical delegates may only bind to critical methods. These binding rules ensure that the only code that can invoke a method via a delegate could have also invoked the same method directly. For example, binding rules prevent transparent code from calling critical code directly via a transparent delegate.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this warning, change the transparency of the delegate or of the method that it binds so that the transparency of the two are equivalent.
+</p>
+<h2>When to Suppress Warnings</h2>
+
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+using System.Security;
+
+namespace TransparencyWarningsDemo
+{
+
+    public delegate void TransparentDelegate();
+
+    [SecurityCritical]
+    public delegate void CriticalDelegate();
+
+    public class TransparentType
+    {
+        void DelegateBinder()
+        {
+            // CA2133 violation - binding a transparent delegate to a critical method
+            TransparentDelegate td = new TransparentDelegate(CriticalTarget);
+
+            // CA2133 violation - binding a critical delegate to a transparent method
+            CriticalDelegate cd = new CriticalDelegate(TransparentTarget);
+        }
+
+        [SecurityCritical]
+        void CriticalTarget() { }
+
+        void TransparentTarget() { }
+    }
+}
+</pre>
+
+
+
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/dd997710.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/dd997710.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="MethodsMustOverrideWithConsistentTransparency">
+    <configKey>CA2134</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2134: Methods must keep consistent transparency when overriding base methods]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            This rule fires when a method marked with the <code>SecurityCriticalAttribute</code> overrides a method that is transparent or marked with the <code>SecuritySafeCriticalAttribute</code>. The rule also fires when a method that is transparent or marked with the <code>SecuritySafeCriticalAttribute</code> overrides a method that is marked with a <code>SecurityCriticalAttribute</code>.
+            The rule is applied when overriding a virtual method or implementing an interface.
+
+
+
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule fires on attempts to change the security accessibility of a method further up the inheritance chain. For example, if a virtual method in a base class is transparent or safe-critical, then the derived class must override it with a transparent or safe-critical method. Conversely, if the virtual is security critical, the derived class must override it with a security critical method. The same rule applies for implementing interface methods.
+            Transparency rules are enforced when the code is JIT compiled instead of at runtime, so that the transparency calculation does not have dynamic type information. Therefore, the result of the transparency calculation must be able to be determined solely from the static types being JIT-compiled, regardless of the dynamic type.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the transparency of the method that is overriding a virtual method or implementing an interface to match the transparency of the virtual or interface method.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress warnings from this rule. Violations of this rule will result in a runtime <code>TypeLoadException</code> for assemblies that use level 2 transparency.
+</p>
+<h2>Examples</h2>
+
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+using System.Security;
+
+namespace TransparencyWarningsDemo
+{
+
+    public interface IInterface
+    {
+        void TransparentInterfaceMethod();
+
+        [SecurityCritical]
+        void CriticalInterfaceMethod();
+    }
+
+    public class Base
+    {
+        public virtual void TransparentVirtual() { }
+
+        [SecurityCritical]
+        public virtual void CriticalVirtual() { }
+    }
+
+    public class Derived : Base, IInterface
+    {
+        // CA2134 violation - implementing a transparent method with a critical one.  This can be fixed by any of: 
+        //   1. Making IInterface.TransparentInterfaceMethod security critical 
+        //   2. Making Derived.TransparentInterfaceMethod transparent 
+        //   3. Making Derived.TransparentInterfaceMethod safe critical
+        [SecurityCritical]
+        public void TransparentInterfaceMethod() { }
+
+        // CA2134 violation - implementing a critical method with a transparent one.  This can be fixed by any of: 
+        //   1. Making IInterface.CriticalInterfaceMethod transparent 
+        //   2. Making IInterface.CriticalInterfaceMethod safe critical 
+        //   3. Making Derived.TransparentInterfaceMethod critical 
+        public void CriticalInterfaceMethod() { }
+
+        // CA2134 violation - overriding a transparent method with a critical one.  This can be fixed by any of: 
+        //   1. Making Base.TrasnparentVirtual critical 
+        //   2. Making Derived.TransparentVirtual transparent 
+        //   3. Making Derived.TransparentVirtual safe critical
+        [SecurityCritical]
+        public override void TransparentVirtual() { }
+
+        // CA2134 violation - overriding a critical method with a transparent one.  This can be fixed by any of: 
+        //   1. Making Base.CriticalVirtual transparent 
+        //   2. Making Base.CriticalVirtual safe critical 
+        //   3. Making Derived.CriticalVirtual critical 
+        public override void CriticalVirtual() { }
+    }
+
+}
+</pre>
+
+
+
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/dd997447.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/dd997447.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="SecurityRuleSetLevel2MethodsShouldNotBeProtectedWithLinkDemands">
+    <configKey>CA2135</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2135: Level 2 assemblies should not contain LinkDemands]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A class or class member is using a <code>LinkDemand</code> in an application that is using Level 2 security.
+</p>
+<h2>Rule Description</h2>
+<p>
+            LinkDemands are deprecated in the level 2 security rule set. Instead of using LinkDemands to enforce security at just-in-time (JIT) compilation time, mark the methods, types, and fields with the <code>SecurityCriticalAttribute</code> attribute.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, remove the <code>LinkDemand</code> and mark the type or member with the <code>SecurityCriticalAttribute</code> attribute.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/dd997569.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/dd997569.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="TransparencyAnnotationsShouldNotConflict">
+    <configKey>CA2136</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2136: Members should not have conflicting transparency annotations]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            This rule fires when a type member is marked with a <code>System.Security</code> security attribute that has a different transparency than the security attribute of a container of the member.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Transparency attributes are applied from code elements of larger scope to elements of smaller scope. The transparency attributes of code elements with larger scope take precedence over transparency attributes of code elements that are contained in the first element. For example, a class that is marked with the <code>SecurityCriticalAttribute</code> attribute cannot contain a method that is marked with the <code>SecuritySafeCriticalAttribute</code> attribute.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix this violation, remove the security attribute from the code element that has lower scope, or change its attribute to be the same as the containing code element.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress warnings from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb264493.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb264493.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="TransparentMethodsMustBeVerifiable">
+    <configKey>CA2137</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2137: Transparent methods must contain only verifiable IL]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method contains unverifiable code or returns a type by reference.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule fires on attempts by security transparent code to execute unverifiable MSIL (Microsoft Intermediate Language). However, the rule does not contain a full IL verifier, and instead uses heuristics to catch most violations of MSIL verification.
+            To be certain that your code contains only verifiable MSIL, run <code>Peverify.exe (PEVerify Tool)</code> on your assembly. Run PEVerify with the /transparent option which limits the output to only unverifiable transparent methods which would cause an error. If the /transparent option is not used, PEVerify also verifies critical methods that are allowed to contain unverifiable code.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, mark the method with the <code>SecurityCriticalAttribute</code> or <code>SecuritySafeCriticalAttribute</code> attribute, or remove the unverifiable code.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/dd983954.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/dd983954.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="TransparentMethodsMustNotCallSuppressUnmanagedCodeSecurityMethods">
+    <configKey>CA2138</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2138: Transparent methods must not call methods with the SuppressUnmanagedCodeSecurity attribute]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A security transparent method calls a method that is marked with the <code>SuppressUnmanagedCodeSecurityAttribute</code> attribute.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule fires on any transparent method that calls directly into native code, for example, by using a via a P/Invoke (platform invoke) call. P/Invoke and COM interop methods that are marked with the <code>SuppressUnmanagedCodeSecurityAttribute</code> attribute result in a LinkDemand being done against the calling method. Because security transparent code cannot satisfy LinkDemands, the code also cannot call methods that are marked with the SuppressUnmanagedCodeSecurity attribute, or methods of class that is marked with SuppressUnmanagedCodeSecurity attribute. The method will fail, or the demand will be converted to a full demand.
+            Violations of this rule lead to a <code>MethodAccessException</code> in the Level 2 security transparency model, and a full demand for <code>UnmanagedCode</code> in the Level 1 transparency model.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, remove the <code>SuppressUnmanagedCodeSecurityAttribute</code> attribute and mark the method with the <code>SecurityCriticalAttribute</code> or the <code>SecuritySafeCriticalAttribute</code> attribute.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/dd997711.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/dd997711.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="TransparentMethodsMustNotHandleProcessCorruptingExceptions">
+    <configKey>CA2139</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2139: Transparent methods may not use the HandleProcessCorruptingExceptions attribute]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A transparent method is marked with the <code>HandleProcessCorruptedStateExceptionsAttribute</code> attribute.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule fires any method which is transparent and attempts to handle a process corrupting exception by using the <code>HandleProcessCorruptedStateExceptionsAttribute</code> attribute. A process corrupting exception is a CLR version 4.0 exception classification of exceptions such <code>AccessViolationException</code>. The HandleProcessCorruptedStateExceptionsAttribute attribute may only be used by security critical methods, and will be ignored if it is applied to a transparent method. To handle process corrupting exceptions, this method must become security critical or security safe-critical.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, remove the <code>HandleProcessCorruptedStateExceptionsAttribute</code> attribute, or mark the method with the <code>SecurityCriticalAttribute</code> or the <code>SecuritySafeCriticalAttribute</code> attribute.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/dd997565.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/dd997565.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="TransparentMethodsMustNotReferenceCriticalCode">
+    <configKey>CA2140</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2140: Transparent code must not reference security critical items]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A transparent method:
+            <ul>
+              <li>
+                handles a security critical security exception type
+              </li>
+              <li>
+                has a parameter that is marked as a security critical type
+              </li>
+              <li>
+                has a generic parameter with a security critical constraints
+              </li>
+              <li>
+                has a local variable of a security critical type
+              </li>
+              <li>
+                references a type that is marked as security critical
+              </li>
+              <li>
+                calls a method that is marked as security critical
+              </li>
+              <li>
+                references a field that is marked as security critical
+              </li>
+              <li>
+                returns a type that is marked as security critical
+              </li>
+            </ul>
+</p>
+<h2>Rule Description</h2>
+<p>
+            A code element that is marked with the <code>SecurityCriticalAttribute</code>  attribute is security critical. A transparent method cannot use a security critical element. If a transparent type attempts to use a security critical type a <code>TypeAccessException</code>, <code>MethodAccessException</code> , or <code>FieldAccessException</code> is raised.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, do one of the following:
+            <ul>
+              <li>
+                Mark the code element that uses the security critical code with the <code>SecurityCriticalAttribute</code> attribute
+                - or -
+              </li>
+              <li>
+                Remove the <code>SecurityCriticalAttribute</code> attribute from the code elements that are marked as security critical and instead mark them with the <code>SecuritySafeCriticalAttribute</code> or <code>SecurityTransparentAttribute</code> attribute.
+              </li>
+            </ul>
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb264475.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb264475.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="TransparentMethodsMustNotSatisfyLinkDemands">
+    <configKey>CA2141</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2141: Transparent methods must not satisfy LinkDemands]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A security transparent method calls a method in an assembly that is not marked with the <code>AllowPartiallyTrustedCallersAttribute</code> (APTCA) attribute, or a security transparent method satisfies a SecurityAction<code>.LinkDemand</code> for a type or a method.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Satisfying a LinkDemand is a security sensitive operation which can cause unintentional elevation of privilege. Security transparent code must not satisfy LinkDemands, because it is not subject to the same security audit requirements as security critical code. Transparent methods in security rule set level 1 assemblies will cause all LinkDemands they satisfy to be converted to full demands at run time, which can cause performance problems. In security rule set level 2 assemblies, transparent methods will fail to compile in the just-in-time (JIT) compiler if they attempt to satisfy a LinkDemand.
+            In assemblies that usee Level 2 security, attempts by a security transparent method to satisfy a LinkDemand or call a method in a non-APTCA assembly raises a <code>MethodAccessException</code>; in Level 1 assemblies the LinkDemand becomes a full Demand.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, mark the accessing method with the <code>SecurityCriticalAttribute</code> or <code>SecuritySafeCriticalAttribute</code> attribute, or remove the LinkDemand from the accessed method.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/dd997445.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/dd997445.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="TransparentMethodsShouldNotBeProtectedWithLinkDemands">
+    <configKey>CA2142</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2142: Transparent code should not be protected with LinkDemands]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A transparent method requires a <code>LinkDemand</code> or other security demand.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule fires on transparent methods which require LinkDemands to access them. Security transparent code should not be responsible for verifying the security of an operation, and therefore should not demand permissions. Because transparent methods are supposed to be security neutral, they should not be making any security decisions. Additionally, safe critical code, which does make security decisions, should not be relying on transparent code to have previously made such a decision.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, remove the link demand on the transparent method or mark the method with <code>SecuritySafeCriticalAttribute</code> attribute if it is performing security checks, such as security demands.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/dd997567.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/dd997567.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="TransparentMethodsShouldNotDemand">
+    <configKey>CA2143</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2143: Transparent methods should not use security demands]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A tranparent type or method is declaratively marked with a <code>System.Security.Permissions.SecurityAction</code><code>.Demand</code> demand or the method calls the <code>CodeAccessPermission.Demand</code> method.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Security transparent code should not be responsible for verifying the security of an operation, and therefore should not demand permissions. Security transparent code should use full demands to make security decisions and safe-critical code should not rely on transparent code to have made the full demand. Any code that performs security checks, such as security demands, should be safe-critical instead.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            In general, to fix a violation of this rule, mark the method with the <code>SecuritySafeCriticalAttribute</code> attribute. You can also remove the demand.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/dd997566.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/dd997566.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="TransparentMethodsShouldNotLoadAssembliesFromByteArrays">
+    <configKey>CA2144</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2144: Transparent code should not load assemblies from byte arrays]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A transparent method loads an assembly from a byte array using one of the following methods:
+            <ul>
+              <li>
+
+
+                    <code>Load</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>Load</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>Load</code>
+
+              </li>
+            </ul>
+</p>
+<h2>Rule Description</h2>
+<p>
+            The security review for transparent code is not as thorough as the security review for critical code, because transparent code cannot perform security sensitive actions. Assemblies loaded from a byte array might not be noticed in transparent code, and that byte array might contain critical, or more importantly safe-critical code, that does need to be audited. Therefore, transparent code should not load assemblies from a byte array.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, mark the method that is loading the assembly with the <code>SecurityCriticalAttribute</code> or the <code>SecuritySafeCriticalAttribute</code> attribute.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/dd997568.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/dd997568.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="TransparentMethodsShouldNotUseSuppressUnmanagedCodeSecurity">
+    <configKey>CA2145</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2145: Transparent methods should not be decorated with the SuppressUnmanagedCodeSecurityAttribute]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A transparent method, a method that is marked with the <code>SecuritySafeCriticalAttribute</code> method, or a type that contains a method is marked with the <code>SuppressUnmanagedCodeSecurityAttribute</code> attribute.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Methods decorated with the <code>SuppressUnmanagedCodeSecurityAttribute</code> attribute have an implicit LinkDemand placed upon any method that calls it. This LinkDemand requires that the calling code be security critical. Marking the method that uses SuppressUnmanagedCodeSecurity with the <code>SecurityCriticalAttribute</code> attribute makes this requirement more obvious for callers of the method.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, mark the method or type with the <code>SecurityCriticalAttribute</code> attribute.
+</p>
+<h2>When to Suppress Warnings</h2>
+
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace TransparencyWarningsDemo
+{
+
+    public class SafeNativeMethods
+    {
+        // CA2145 violation - transparent method marked SuppressUnmanagedCodeSecurity.  This should be fixed by 
+        // marking this method SecurityCritical.
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [SuppressUnmanagedCodeSecurity]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool Beep(uint dwFreq, uint dwDuration);
+    }
+}
+</pre>
+
+
+
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/dd997570.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/dd997570.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="TypesMustBeAtLeastAsCriticalAsBaseTypes">
+    <configKey>CA2146</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2146: Types must be at least as critical as their base types and interfaces]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A transparent type is derived from a type that is marked with the <code>SecuritySafeCriticalAttribute</code> or the <code>SecurityCriticalAttribute</code>, or a type that is marked with the <code>SecuritySafeCriticalAttribute</code> attribute is derived from a type that is marked with the <code>SecurityCriticalAttribute</code> attribute.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule fires when a derived type has a security transparency attribute that is not as critical as its base type or implemented interface. Only critical types can derive from critical base types or implement critical interfaces, and only critical or safe-critical types can derive from safe-critical base types or implement safe-critical interfaces. Violations of this rule in level 2 transparency result in a <code>TypeLoadException</code> for the derived type.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix this violation, mark the derived or implementing type with a transparency attribute that is at least as critical as the base type or interface.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/dd997443.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/dd997443.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="SecurityTransparentCodeShouldNotAssert">
+    <configKey>CA2147</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2147: Transparent methods may not use security asserts]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            Code that is marked as <code>SecurityTransparentAttribute</code> is not granted sufficient permissions to assert.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule analyzes all methods and types in an assembly which is either 100% transparent or mixed transparent/critical, and flags any declarative or imperative usage of <code>Assert</code>.
+            At run time, any calls to <code>Assert</code> from transparent code will cause a <code>InvalidOperationException</code> to be thrown. This can occur in both 100% transparent assemblies, and also in mixed transparent/critical assemblies where a method or type is declared transparent, but includes a declarative or imperative Assert.
+            The .NET Framework 2.0 introduced a feature named transparency. Individual methods, fields, interfaces, classes, and types can be either transparent or critical.
+            Transparent code is not allowed to elevate security privileges. Therefore, any permissions granted or demanded of it are automatically passed through the code to the caller or host application domain. Examples of elevations include Asserts, LinkDemands, SuppressUnmanagedCode, and <code>unsafe</code> code.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To resolve the issue, either mark the code which calls the Assert with the <code>SecurityCriticalAttribute</code>, or remove the Assert.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a message from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb264482.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb264482.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="TransparentMethodsMustNotCallNativeCode">
+    <configKey>CA2149</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2149: Transparent methods must not call into native code]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method calls a native function through a method stub such as P/Invoke.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule fires on any transparent method which calls directly into native code, for example, through a P/Invoke. Violations of this rule lead to a <code>MethodAccessException</code> in the level 2 transparency model, and a full demand for <code>UnmanagedCode</code> in the level 1 transparency model.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, mark the method that calls the native code with the <code>SecurityCriticalAttribute</code> or <code>SecuritySafeCriticalAttribute</code> attribute.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ee155709.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ee155709.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="CA2151">
+    <configKey>CA2151</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2151: Fields with critical types should be security critical]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A security transparent field or a safe critical field is declared. Its type is specified as security critical. For example:
+
+
+
+
+
+
+
+
+
+            <pre>
+[assembly: AllowPartiallyTrustedCallers]
+
+   [SecurityCritical]
+   class Type1 { } // Security Critical type
+
+   class Type2 // Security transparent type
+   {
+      Type1 m_field; // CA2151, transparent field of critical type
+   }
+</pre>
+
+
+
+
+In this example, m_field is a security transparent field of a type that is security critical.
+
+
+
+
+
+
+                Rule Description
+
+
+
+
+
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, mark the field with the <code>SecurityCriticalAttribute</code> attribute, or make the type that is referenced by the field eith security transparent or safe critical.
+
+
+
+
+
+
+
+
+
+            <pre>
+// Fix 1: Make the referencing field security critical
+[assembly: AllowPartiallyTrustedCallers]
+
+   [SecurityCritical]
+   class Type1 { } // Security Critical type
+
+   class Type2 // Security transparent type
+   {
+      [SecurityCritical]
+      Type1 m_field; // Fixed: critical type, critical field
+   }
+
+// Fix 2: Make the referencing field security critical
+[assembly: AllowPartiallyTrustedCallers]
+
+
+   class Type1 { } // Type1 is now transparent
+
+   class Type2 // Security transparent type
+   {
+      [SecurityCritical]
+      Type1 m_field; // Fixed: critical type, critical field
+   }
+</pre>
+
+
+
+
+
+
+
+
+
+
+
+                When to Suppress Warnings
+
+
+
+
+
+</p>
+<h2>Code</h2>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace TransparencyWarningsDemo
+{
+
+    public class SafeNativeMethods
+    {
+        // CA2145 violation - transparent method marked SuppressUnmanagedCodeSecurity.  This should be fixed by 
+        // marking this method SecurityCritical.
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [SuppressUnmanagedCodeSecurity]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool Beep(uint dwFreq, uint dwDuration);
+    }
+}
+</pre>
+
+
+
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/dn621098.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/dn621098.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="RethrowToPreserveStackDetails">
+    <configKey>CA2200</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2200: Rethrow to preserve stack details]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An exception is re-thrown and the exception is explicitly specified in the <code>throw</code> statement.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Once an exception is thrown, part of the information it carries is the stack trace. The stack trace is a list of the method call hierarchy that starts with the method that throws the exception and ends with the method that catches the exception. If an exception is re-thrown by specifying the exception in the <code>throw</code> statement, the stack trace is restarted at the current method and the list of method calls between the original method that threw the exception and the current method is lost. To keep the original stack trace information with the exception, use the <code>throw</code> statement without specifying the exception.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, re-throw the exception without specifying the exception explicitly.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182363.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182363.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotRaiseReservedExceptionTypes">
+    <configKey>CA2201</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2201: Do not raise reserved exception types]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method raises an exception type that is too general or that is reserved by the runtime.
+</p>
+<h2>Rule Description</h2>
+<p>
+            The following exception types are too general to provide sufficient information to the user:
+            <ul>
+              <li>
+
+
+                    <code>System.Exception</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.ApplicationException</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.SystemException</code>
+
+
+              </li>
+            </ul>
+            The following exception types are reserved and should be thrown only by the common language runtime:
+            <ul>
+              <li>
+
+
+                    <code>System.ExecutionEngineException</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.IndexOutOfRangeException</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.NullReferenceException</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.OutOfMemoryException</code>
+
+
+              </li>
+            </ul>
+
+              Do Not Throw General Exceptions
+
+            If you throw a general exception type, such as <code>Exception</code> or <code>SystemException</code> in a library or framework, it forces consumers to catch all exceptions, including unknown exceptions that they do not know how to handle.
+            Instead, either throw a more derived type that already exists in the framework, or create your own type that derives from <code>Exception</code>.
+
+              Throw Specific Exceptions
+
+            The following table shows parameters and which exceptions to throw when you validate the parameter, including the value parameter in the set accessor of a property:
+
+
+
+
+
+
+
+                    Parameter Description
+
+
+                    Exception
+
+
+
+
+
+
+                        <code>null</code>
+                       reference 
+
+
+
+
+                        <code>System.ArgumentNullException</code>
+
+
+
+
+
+
+                    Outside the allowed range of values (such as an index for a collection or list)
+
+
+
+
+                        <code>System.ArgumentOutOfRangeException</code>
+
+
+
+
+
+
+                    Invalid <code>enum</code> value
+
+
+
+
+                        <code>System.ComponentModel.InvalidEnumArgumentException</code>
+
+
+
+
+
+
+                    Contains a format that does not meet the parameter specifications of a method (such as the format string for ToString(String))
+
+
+
+
+                        <code>System.FormatException</code>
+
+
+
+
+
+
+                    Otherwise invalid
+
+
+
+
+                        <code>System.ArgumentException</code>
+
+
+
+
+
+
+            When an operation is invalid for the current state of an object    throw <code>System.InvalidOperationException</code>
+            When an operation is performed on an object that has been disposed    throw <code>System.ObjectDisposedException</code>
+            When an operation is not supported (such as in an overridden Stream.Write in a Stream opened for reading)    throw <code>System.NotSupportedException</code>
+            When a conversion would result in an overflow (such as in a explicit cast operator overload)    throw <code>System.OverflowException</code>
+            For all other situations, consider creating your own type that derives from <code>Exception</code> and throw that.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the type of the thrown exception to a specific type that is not one of the reserved types.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:DoNotCatchGeneralExceptionTypes}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182338.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182338.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotDisposeObjectsMultipleTimes">
+    <configKey>CA2202</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2202: Do not dispose objects multiple times]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method implementation contains code paths that could cause multiple calls to <code>IDisposable.Dispose</code> or a Dispose equivalent, such as a Close() method on some types, on the same object.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A correctly implemented <code>Dispose</code> method can be called multiple times without throwing an exception. However, this is not guaranteed and to avoid generating a <code>System.ObjectDisposedException</code> you should not call <code>Dispose</code> more than one time on an object.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:DisposeObjectsBeforeLosingScope}
+
+
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the implementation so that regardless of the code path, <code>Dispose</code> is called only one time for the object.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule. Even if <code>Dispose</code> for the object is known to be safely callable multiple times, the implementation might change in the future.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182334.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182334.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="LiteralsShouldBeSpelledCorrectly">
+    <configKey>CA2204</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2204: Literals should be spelled correctly]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method passes a literal string to that is used in a parameter or property that requires a localized string and the literal string contains one or more words that are not recognized by the Microsoft spelling checker library.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule checks a literal string that is passed as a value to a parameter or property when one or more of the following cases is true:
+            <ul>
+              <li>
+                The <code>LocalizableAttribute</code> attribute of the parameter or property is set to true.
+              </li>
+              <li>
+                The parameter or property name contains "Text", "Message", or "Caption".
+              </li>
+              <li>
+                The name of the string parameter that is passed to a Console.Write or Console.WriteLine method is either "value" or "format".
+              </li>
+            </ul>
+            This rule parses the literal string into words, tokenizing compound words, and checks the spelling of each word/token. For information about the parsing algorithm, see CA1704: Identifiers should be spelled correctly.
+            By default, the English (en) version of the spelling checker is used.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, correct the spelling of the word or add the word to a custom dictionary. For information about how to use custom dictionaries, see How to: Customize the Code Analysis Dictionary.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule. Correctly spelled words reduce the learning curve required for new software libraries.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                CA1704: Identifiers should be spelled correctly
+
+
+
+
+                CA1703: Resource strings should be spelled correctly
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb264488.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb264488.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="UseManagedEquivalentsOfWin32Api">
+    <configKey>CA2205</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2205: Use managed equivalents of Win32 API]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A platform invoke method is defined and a method with the equivalent functionality exists in the .NET Framework class library.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A platform invoke method is used to call an unmanaged DLL function and is defined using the <code>System.Runtime.InteropServices.DllImportAttribute</code> attribute, or the <code>Declare</code> keyword in Visual Basic. An incorrectly defined platform invoke method can lead to runtime exceptions because of issues such as a misnamed function, faulty mapping of parameter and return value data types, and incorrect field specifications, such as the calling convention and character set. If available, it is generally simpler and less error prone to call the equivalent managed method than to define and call the unmanaged method directly. Calling a platform invoke method can also lead to additional security issues that need to be addressed.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, replace the call to the unmanaged function with a call to its managed equivalent.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Suppress a warning from this rule if the suggested replacement method does not provide the needed functionality.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:CallGetLastErrorImmediatelyAfterPInvoke}<br/>
+
+
+
+
+                {rule:fxcop:MovePInvokesToNativeMethodsClass}<br/>
+
+
+
+
+                {rule:fxcop:PInvokeEntryPointsShouldExist}<br/>
+
+
+
+
+                {rule:fxcop:PInvokesShouldNotBeVisible}<br/>
+
+
+
+
+                {rule:fxcop:SpecifyMarshalingForPInvokeStringArguments}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182365.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182365.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="InitializeValueTypeStaticFieldsInline">
+    <configKey>CA2207</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2207: Initialize value type static fields inline]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A value-type declares an explicit static constructor.
+</p>
+<h2>Rule Description</h2>
+<p>
+            When a value-type is declared, it undergoes a default initialization where all value-type fields are set to zero and all reference-type fields are set to <code>null</code> (<code>Nothing</code> in Visual Basic). An explicit static constructor is only guaranteed to run before an instance constructor or static member of the type is called. Therefore, if the type is created without calling an instance constructor, the static constructor is not guaranteed to run.
+            If all static data is initialized inline and no explicit static constructor is declared, the C# and Visual Basic compilers add the <code>beforefieldinit</code> flag to the MSIL class definition. The compilers also add a private static constructor that contains the static initialization code. This private static constructor is guaranteed to run before any static fields of the type are accessed.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule initialize all static data when it is declared and remove the static constructor.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:InitializeReferenceTypeStaticFieldsInline}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182346.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182346.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="InstantiateArgumentExceptionsCorrectly">
+    <configKey>CA2208</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2208: Instantiate argument exceptions correctly]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            Possible causes include the following situations:
+            <ul>
+              <li>
+                A call is made to the default (parameterless) constructor of an exception type that is, or derives from [System.ArgumentException].
+              </li>
+              <li>
+                An incorrect string argument is passed to a parameterized constructor of an exception type that is, or derives from [System.ArgumentException.]
+              </li>
+            </ul>
+</p>
+<h2>Rule Description</h2>
+<p>
+            Instead of calling the default constructor, call one of the constructor overloads that allows a more meaningful exception message to be provided. The exception message should target the developer and clearly explain the error condition and how to correct or avoid the exception.
+            The signatures of the one and two string constructors of <code>ArgumentException</code> and its derived types are not consistent with respect to the message and paramName parameters. Make sure these constructors are called with the correct string arguments. The signatures are as follows:
+
+
+                <code>ArgumentException</code>
+              (string message)
+
+
+                <code>ArgumentException</code>
+              (string message, string paramName)
+
+
+                <code>ArgumentNullException</code>
+              (string paramName)
+
+
+                <code>ArgumentNullException</code>
+              (string paramName, string message)
+
+
+                <code>ArgumentOutOfRangeException</code>
+              (string paramName)
+
+
+                <code>ArgumentOutOfRangeException</code>
+              (string paramName, string message)
+
+
+                <code>DuplicateWaitObjectException</code>
+              (string parameterName)
+
+
+                <code>DuplicateWaitObjectException</code>
+              (string parameterName, string message)
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, call a constructor that takes a message, a parameter name, or both, and make sure the arguments are proper for the type of <code>ArgumentException</code> being called.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule only if a parameterized constructor is called with the correct string arguments.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182347.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182347.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AssembliesShouldHaveValidStrongNames">
+    <configKey>CA2210</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2210: Assemblies should have valid strong names]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An assembly is not signed with a strong name, the strong name could not be verified, or the strong name would not be valid without the current registry settings of the computer.
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule retrieves and verifies the strong name of an assembly. A violation occurs if any of the following are true:
+            <ul>
+              <li>
+                The assembly does not have a strong name.
+              </li>
+              <li>
+                The assembly was altered after signing.
+              </li>
+              <li>
+                The assembly is delay-signed.
+              </li>
+              <li>
+                The assembly was incorrectly signed, or signing failed.
+              </li>
+              <li>
+                The assembly requires registry settings to pass verification. For example, the Strong Name tool (Sn.exe) was used to skip verification for the assembly.
+              </li>
+            </ul>
+            The strong name protects clients from unknowingly loading an assembly that has been tampered with. Assemblies without strong names should not be deployed outside very limited scenarios. If you share or distribute assemblies that are not correctly signed, the assembly can be tampered with, the common language runtime might not load the assembly, or the user might have to disable verification on his or her computer. An assembly without a strong name has from the following drawbacks:
+            <ul>
+              <li>
+                Its origins cannot be verified.
+              </li>
+              <li>
+                The common language runtime cannot warn users if the contents of the assembly have been altered.
+              </li>
+              <li>
+                It cannot be loaded into the global assembly cache.
+              </li>
+            </ul>
+            Note that to load and analyze a delay-signed assembly, you must disable verification for the assembly.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+
+              To create a key file
+            Use one of the following procedures:
+            <ul>
+              <li>
+                Use the Assembly Linker tool (Al.exe) provided by the .NET Framework SDK.
+              </li>
+              <li>
+                For the .NET Framework v1.0 or v1.1, use either the <code>System.Reflection.AssemblyKeyFileAttribute</code> or <code>System.Reflection.AssemblyKeyNameAttribute</code> attribute.
+              </li>
+              <li>
+                For the .NET Framework 2.0, use either the /keyfile or /keycontainer compiler option /KEYFILE (Specify Key or Key Pair to Sign an Assembly) or <code>/KEYCONTAINER (Specify a Key Container to Sign an Assembly)</code> linker option in C++).
+              </li>
+            </ul>
+
+              To sign your assembly with a strong name in Visual Studio
+
+
+              <li>
+                In Visual Studio, open your solution.
+              </li>
+              <li>
+                In Solution Explorer, right-click your project and then click Properties.
+              </li>
+              <li>
+                Click the Signing tab, and select the Sign the assembly check box.
+              </li>
+              <li>
+                From Choose a strong name key file, select New.
+                The Create Strong Name Key window will display.
+              </li>
+              <li>
+                In Key file name, type a name for your strong name key.
+              </li>
+              <li>
+                Choose whether to protect the key with a password, and then click OK.
+              </li>
+              <li>
+                In Solution Explorer, right-click your project and then click Build.
+              </li>
+
+
+
+
+
+              To sign your assembly with a strong name outside Visual Studio
+
+            <ul>
+              <li>
+                Use the strong name tool (Sn.exe) that is provided by the .NET Framework SDK. For more information, see Sn.exe (Strong Name Tool).
+              </li>
+            </ul>
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Only suppress a warning from this rule if the assembly is used in an environment where tampering with the contents is not a concern.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182127.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182127.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="NonConstantFieldsShouldNotBeVisible">
+    <configKey>CA2211</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2211: Non-constant fields should not be visible]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected static field is not constant nor is it read-only.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Static fields that are neither constants nor read-only are not thread-safe. Access to such a field must be carefully controlled and requires advanced programming techniques for synchronizing access to the class object. Because these are difficult skills to learn and master, and testing such an object poses its own challenges, static fields are best used to store data that does not change. This rule applies to libraries; applications should not expose any fields.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, make the static field constant or read-only. If this is not possible, redesign the type to use an alternative mechanism such as a thread-safe property that manages thread-safe access to the underlying field. Realize that issues such as lock contention and deadlocks might affect the performance and behavior of the library.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if you are developing an application and therefore have full control over access to the type that contains the static field. Library designers should not suppress a warning from this rule; using non-constant static fields can make using the library difficult for developers to use correctly.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182353.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182353.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotMarkServicedComponentsWithWebMethod">
+    <configKey>CA2212</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2212: Do not mark serviced components with WebMethod]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method in a type that inherits from <code>System.EnterpriseServices.ServicedComponent</code> is marked with <code>System.Web.Services.WebMethodAttribute</code>.
+</p>
+<h2>Rule Description</h2>
+<p>
+
+
+                <code>WebMethodAttribute</code>
+               applies to methods within an XML Web service that were created by using ASP.NET; it makes the method callable from remote Web clients. The method and class must be public and executing in an ASP.NET Web application. <code>ServicedComponent</code> types are hosted by COM+ applications and can use COM+ services. <code>WebMethodAttribute</code> is not applied to <code>ServicedComponent</code> types because they are not intended for the same scenarios. Specifically, adding the attribute to the <code>ServicedComponent</code> method does not make the method callable from remote Web clients. Because <code>WebMethodAttribute</code> and a <code>ServicedComponent</code> method have conflicting behaviors and requirements for context and transaction flow, the behavior of the method will be incorrect in some scenarios.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, remove the attribute from the <code>ServicedComponent</code> method.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule. There are no scenarios where combining these elements is correct.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182336.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182336.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DisposableFieldsShouldBeDisposed">
+    <configKey>CA2213</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2213: Disposable fields should be disposed]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type that implements <code>System.IDisposable</code> declares fields that are of types that also implement <code>IDisposable</code>. The <code>Dispose</code> method of the field is not called by the <code>Dispose</code> method of the declaring type.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A type is responsible for disposing of all its unmanaged resources; this is accomplished by implementing <code>IDisposable</code>. This rule checks to see whether a disposable type T declares a field F that is an instance of a disposable type FT. For each field F, the rule attempts to locate a call to FT.Dispose. The rule searches the methods called by T.Dispose, and one level lower (the methods called by the methods called by FT.Dispose).
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, call <code>Dispose</code> on fields that are of types that implement <code>IDisposable</code> if you are responsible for allocating and releasing the unmanaged resources held by the field.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if you are not responsible for releasing the resource held by the field, or if the call to <code>Dispose</code> occurs at a deeper calling level than the rule checks.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182328.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182328.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotCallOverridableMethodsInConstructors">
+    <configKey>CA2214</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2214: Do not call overridable methods in constructors]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The constructor of an unsealed type calls a virtual method defined in its class.
+</p>
+<h2>Rule Description</h2>
+<p>
+            When a virtual method is called, the actual type that executes the method is not selected until run time. When a constructor calls a virtual method, it is possible that the constructor for the instance that invokes the method has not executed.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, do not call a type's virtual methods from within the type's constructors.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule. The constructor should be redesigned to eliminate the call to the virtual method.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182331.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182331.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DisposeMethodsShouldCallBaseClassDispose">
+    <configKey>CA2215</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2215: Dispose methods should call base class dispose]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type that implements <code>System.IDisposable</code> inherits from a type that also implements <code>IDisposable</code>. The <code>Dispose</code> method of the inheriting type does not call the <code>Dispose</code> method of the parent type.
+</p>
+<h2>Rule Description</h2>
+<p>
+            If a type inherits from a disposable type, it must call the <code>Dispose</code> method of the base type from within its own <code>Dispose</code> method. Calling the base type method Dispose ensures that any resources created by the base type are released.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, call <code>base</code>.<code>Dispose</code> in your <code>Dispose</code> method.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if the call to <code>base</code>.<code>Dispose</code> occurs at a deeper calling level than the rule checks.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182330.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182330.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DisposableTypesShouldDeclareFinalizer">
+    <configKey>CA2216</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2216: Disposable types should declare finalizer]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type that implements <code>System.IDisposable</code>, and has fields that suggest the use of unmanaged resources, does not implement a finalizer as described by <code>Object.Finalize</code>.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A violation of this rule is reported if the disposable type contains fields of the following types:
+            <ul>
+              <li>
+
+
+                    <code>System.IntPtr</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.UIntPtr</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.Runtime.InteropServices.HandleRef</code>
+
+
+              </li>
+            </ul>
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, implement a finalizer that calls your <code>Dispose</code> method.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if the type does not implement <code>IDisposable</code> for the purpose of releasing unmanaged resources.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:CallGCKeepAliveWhenUsingNativeResources}<br/>
+
+
+
+
+                {rule:fxcop:CallGCSuppressFinalizeCorrectly}<br/>
+
+
+
+
+                {rule:fxcop:TypesThatOwnNativeResourcesShouldBeDisposable}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182329.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182329.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotMarkEnumsWithFlags">
+    <configKey>CA2217</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2217: Do not mark enums with FlagsAttribute]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An externally visible enumeration is marked with <code>FlagsAttribute</code> and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.
+</p>
+<h2>Rule Description</h2>
+<p>
+            An enumeration should have <code>FlagsAttribute</code> present only if each value defined in the enumeration is a power of two, or a combination of defined values.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, remove <code>FlagsAttribute</code> from the enumeration.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:MarkEnumsWithFlags}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182335.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182335.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="OverrideGetHashCodeOnOverridingEquals">
+    <configKey>CA2218</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2218: Override GetHashCode on overriding Equals]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public type overrides <code>Object.Equals</code> but does not override <code>Object.GetHashCode</code>.
+</p>
+<h2>Rule Description</h2>
+<p>
+
+
+                <code>GetHashCode</code>
+               returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code to ensure that instances of the following types work correctly:
+            <ul>
+              <li>
+
+                  <code>HashTable</code>
+
+              </li>
+              <li>
+
+
+                    <code>System.Collections.SortedList</code>
+
+
+              </li>
+              <li>
+
+                  Dictionary
+
+              </li>
+              <li>
+
+                  SortDictionary
+
+              </li>
+              <li>
+
+                  SortList
+
+              </li>
+              <li>
+
+                  HybredDictionary
+
+              </li>
+              <li>
+
+
+                    <code>System.Collections.Specialized.ListDictionary</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.Collections.Specialized.OrderedDictionary</code>
+
+
+              </li>
+              <li>
+                Types that implement IEqualityComparer
+              </li>
+            </ul>
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, provide an implementation of <code>GetHashCode</code>. For a pair of objects of the same type, you must ensure that the implementation returns the same value if your implementation of <code>Equals</code> returns <code>true</code> for the pair.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Class Example</h2>
+
+<h3>Description</h3>
+<p>
+                The following example shows a class (reference type) that violates this rule.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+
+namespace Samples
+{
+    // Violates this rule     
+    public class Point
+    {
+        private readonly int _X;
+        private readonly int _Y;
+
+        public Point(int x, int y)
+        {
+            _X = x;
+            _Y = y;
+        }
+
+        public int X
+        {
+            get { return _X; }
+        }
+
+        public int Y
+        {
+            get { return _Y; }
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+                return false;
+
+            if (GetType() != obj.GetType())
+                return false;
+
+            Point point = (Point)obj;
+
+            if (_X != point.X)
+                return false;
+
+            return _Y == point.Y;
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h3>Comments</h3>
+<p>
+                The following example fixes the violation by overriding GetHashCode.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+
+namespace Samples
+{
+    public struct Point : IEquatable&lt;Point&gt;
+    {
+        private readonly int _X;
+        private readonly int _Y;
+
+        public Point(int x, int y)
+        {
+            _X = x;
+            _Y = y;
+        }
+
+        public int X
+        {
+            get { return _X; }
+        }
+
+        public int Y
+        {
+            get { return _Y; }
+        }
+
+        public override int GetHashCode()
+        {
+            return _X ^ _Y;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is Point))
+                return false;
+
+            return Equals((Point)obj);
+        }
+
+        public bool Equals(Point other)
+        {
+            if (_X != other._X)
+                return false;
+
+            return _Y == other._Y;
+        }
+
+        public static bool operator ==(Point point1, Point point2)
+        {
+            return point1.Equals(point2);
+        }
+
+        public static bool operator !=(Point point1, Point point2)
+        {
+            return !point1.Equals(point2);
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>Structure Example</h2>
+
+<h3>Description</h3>
+<p>
+                The following example shows a structure (value type) that violates this rule.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+
+namespace Samples
+{
+    // Violates this rule     
+    public struct Point : IEquatable&lt;Point&gt;
+    {
+        private readonly int _X;
+        private readonly int _Y;
+
+        public Point(int x, int y)
+        {
+            _X = x;
+            _Y = y;
+        }
+
+        public int X
+        {
+            get { return _X; }
+        }
+
+        public int Y
+        {
+            get { return _Y; }
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is Point))
+                return false;
+
+            return Equals((Point)obj);
+        }
+
+        public bool Equals(Point other)
+        {
+            if (_X != other._X)
+                return false;
+
+            return _Y == other._Y;
+        }
+
+        public static bool operator ==(Point point1, Point point2)
+        {
+            return point1.Equals(point2);
+        }
+
+        public static bool operator !=(Point point1, Point point2)
+        {
+            return !point1.Equals(point2);
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h3>Comments</h3>
+<p>
+                The following example fixes the violation by overriding GetHashCode.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+
+namespace Samples
+{
+    public struct Point : IEquatable&lt;Point&gt;
+    {
+        private readonly int _X;
+        private readonly int _Y;
+
+        public Point(int x, int y)
+        {
+            _X = x;
+            _Y = y;
+        }
+
+        public int X
+        {
+            get { return _X; }
+        }
+
+        public int Y
+        {
+            get { return _Y; }
+        }
+
+        public override int GetHashCode()
+        {
+            return _X ^ _Y;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is Point))
+                return false;
+
+            return Equals((Point)obj);
+        }
+
+        public bool Equals(Point other)
+        {
+            if (_X != other._X)
+                return false;
+
+            return _Y == other._Y;
+        }
+
+        public static bool operator ==(Point point1, Point point2)
+        {
+            return point1.Equals(point2);
+        }
+
+        public static bool operator !=(Point point1, Point point2)
+        {
+            return !point1.Equals(point2);
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:DoNotOverloadOperatorEqualsOnReferenceTypes}<br/>
+
+
+
+
+                {rule:fxcop:OperatorOverloadsHaveNamedAlternates}<br/>
+
+
+
+
+                {rule:fxcop:OperatorsShouldHaveSymmetricalOverloads}<br/>
+
+
+
+
+                {rule:fxcop:OverrideEqualsOnOverloadingOperatorEquals}<br/>
+
+
+
+
+                {rule:fxcop:OverloadOperatorEqualsOnOverridingValueTypeEquals}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182358.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182358.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotRaiseExceptionsInExceptionClauses">
+    <configKey>CA2219</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2219: Do not raise exceptions in exception clauses]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An exception is thrown from a <code>finally</code>, filter, or fault clause.
+</p>
+<h2>Rule Description</h2>
+<p>
+            When an exception is raised in an exception clause, it greatly increases the difficulty of debugging.
+            When an exception is raised in a <code>finally</code> or fault clause, the new exception hides the active exception, if present. This makes the original error hard to detect and debug.
+            When an exception is raised in a filter clause, the runtime silently catches the exception, and causes the filter to evaluate to false. There is no way to tell the difference between the filter evaluating to false and an exception being throw from a filter. This makes it hard to detect and debug errors in the filter's logic.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix this violation of this rule, do not explicitly raise an exception from a <code>finally</code>, filter, or fault clause.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning for this rule. There are no scenarios under which an exception raised in an exception clause provides a benefit to the executing code.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                CA1065: Do not raise exceptions in unexpected locations
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb386041.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb386041.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="FinalizersShouldCallBaseClassFinalizer">
+    <configKey>CA2220</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2220: Finalizers should call base class finalizer]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type that overrides <code>Object.Finalize</code> does not call the <code>Finalize</code> method in its base class.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Finalization must be propagated through the inheritance hierarchy. To ensure this, types must call their base class <code>Finalize</code> method from within their own <code>Finalize</code> method. The C# compiler adds the call to the base class finalizer automatically.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, call the base type's <code>Finalize</code> method from your <code>Finalize</code> method.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule. Some compilers that target the common language runtime insert a call to the base type's finalizer into the Microsoft intermediate language (MSIL). If a warning from this rule is reported, your compiler does not insert the call, and you must add it to your code.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182341.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182341.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="FinalizersShouldBeProtected">
+    <configKey>CA2221</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2221: Finalizers should be protected]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public type implements a finalizer that does not specify family (protected) access.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Finalizers must use the family access modifier. This rule is enforced by the C#, Visual Basic, and Visual C++ compilers.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the finalizer to be family-accessible.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182340.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182340.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotDecreaseInheritedMemberVisibility">
+    <configKey>CA2222</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2222: Do not decrease inherited member visibility]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A private method in an unsealed type has a signature that is identical to a public method declared in a base type. The private method is not final.
+</p>
+<h2>Rule Description</h2>
+<p>
+            You should not change the access modifier for inherited members. Changing an inherited member to private does not prevent callers from accessing the base class implementation of the method. If the member is made private and the type is unsealed, inheriting types can call the last public implementation of the method in the inheritance hierarchy. If you must change the access modifier, either the method should be marked final or its type should be sealed to prevent the method from being overridden.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the access to be non-private. Alternatively, if your programming language supports it, you can make the method final.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182332.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182332.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="MembersShouldDifferByMoreThanReturnType">
+    <configKey>CA2223</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2223: Members should differ by more than return type]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            Two public or protected members have signatures that are identical except for return type.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Although the common language runtime permits the use of return types to differentiate between otherwise identical members, this feature is not in the Common Language Specification, nor is it a common feature of .NET programming languages. When members differ only by return type, developers and development tools might not correctly distinguish between them.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, change the design of the members so that they are unique based only on their names and parameter types, or do not expose the members.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182352.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182352.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="OverrideEqualsOnOverloadingOperatorEquals">
+    <configKey>CA2224</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2224: Override equals on overloading operator equals]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public type implements the equality operator, but does not override <code>Object.Equals</code>.
+</p>
+<h2>Rule Description</h2>
+<p>
+            The equality operator is intended to be a syntactically convenient way to access the functionality of the <code>Equals</code> method. If you implement the equality operator, its logic must be identical to that of <code>Equals</code>.
+            The C# compiler issues a warning if your code violates this rule.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, you should either remove the implementation of the equality operator, or override <code>Equals</code> and have the two methods return the same values. If the equality operator does not introduce inconsistent behavior, you can fix the violation by providing an implementation of <code>Equals</code> that calls the <code>Equals</code> method in the base class.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if the equality operator returns the same value as the inherited implementation of <code>Equals</code>. The Example section includes a type that could safely suppress a warning from this rule.
+</p>
+<h2>Examples of Inconsistent Equality Definitions</h2>
+
+<h3>Description</h3>
+<p>
+                The following example shows a type with inconsistent definitions of equality. BadPoint changes the meaning of equality by providing a custom implementation of the equality operator, but does not override <code>Equals</code> so that it behaves identically.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+
+namespace UsageLibrary
+{
+    public class BadPoint
+    {
+        private int x,y, id;
+        private static int NextId;
+
+        static BadPoint()
+        {
+            NextId = -1;
+        }
+        public BadPoint(int x, int y)
+        {
+            this.x = x;
+            this.y = y;
+            id = ++(BadPoint.NextId);
+        }
+
+        public override string ToString()
+        {
+            return String.Format("([{0}] {1},{2})",id,x,y);
+        }
+
+        public int X {get {return x;}}
+
+        public int Y {get {return x;}}
+        public int Id {get {return id;}}
+
+        public override int GetHashCode()
+        {
+            return id;
+        }
+        // Violates rule: OverrideEqualsOnOverridingOperatorEquals. 
+
+        // BadPoint redefines the equality operator to ignore the id value. 
+        // This is different from how the inherited implementation of  
+        // System.Object.Equals behaves for value types.  
+        // It is not safe to exclude the violation for this type.  
+        public static bool operator== (BadPoint p1, BadPoint p2)
+        {
+            return ((p1.x == p2.x) &amp;&amp; (p1.y == p2.y));
+        }
+        // The C# compiler and rule OperatorsShouldHaveSymmetricalOverloads require this. 
+        public static bool operator!= (BadPoint p1, BadPoint p2)
+        {
+            return !(p1 == p2);
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>Example</h2>
+
+<h3>Description</h3>
+<p>
+                The following example shows a class (reference type) that violates this rule.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+
+namespace Samples
+{
+    // Violates this rule     
+    public class Point
+    {
+        private readonly int _X;
+        private readonly int _Y;
+
+        public Point(int x, int y)
+        {
+            _X = x;
+            _Y = y;
+        }
+
+        public int X
+        {
+            get { return _X; }
+        }
+
+        public int Y
+        {
+            get { return _Y; }
+        }
+
+        public override int GetHashCode()
+        {
+            return _X ^ _Y;
+        }
+
+        public static bool operator ==(Point point1, Point point2)
+        {
+            if (point1 == null || point2 == null)
+                return false;
+
+            if (point1.GetType() != point2.GetType())
+                return false;
+
+            if (point1._X != point2._X)
+                return false;
+
+            return point1._Y == point2._Y;
+        }
+
+        public static bool operator !=(Point point1, Point point2)
+        {
+            return !(point1 == point2);
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>Structure Example</h2>
+
+<h3>Description</h3>
+<p>
+                The following example shows a structure (value type) that violates this rule.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+
+namespace Samples
+{
+    // Violates this rule     
+    public struct Point
+    {
+        private readonly int _X;
+        private readonly int _Y;
+
+        public Point(int x, int y)
+        {
+            _X = x;
+            _Y = y;
+        }
+
+        public int X
+        {
+            get { return _X; }
+        }
+
+        public int Y
+        {
+            get { return _Y; }
+        }
+
+        public override int GetHashCode()
+        {
+            return _X ^ _Y;
+        }
+
+        public static bool operator ==(Point point1, Point point2)
+        {
+            if (point1._X != point2._X)
+                return false;
+
+            return point1._Y == point2._Y;
+        }
+
+        public static bool operator !=(Point point1, Point point2)
+        {
+            return !(point1 == point2);
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:DoNotOverloadOperatorEqualsOnReferenceTypes}<br/>
+
+
+
+
+                {rule:fxcop:OperatorOverloadsHaveNamedAlternates}<br/>
+
+
+
+
+                {rule:fxcop:OperatorsShouldHaveSymmetricalOverloads}<br/>
+
+
+
+
+                {rule:fxcop:OverrideGetHashCodeOnOverridingEquals}<br/>
+
+
+
+
+                {rule:fxcop:OverloadOperatorEqualsOnOverridingValueTypeEquals}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182357.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182357.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="OperatorOverloadsHaveNamedAlternates">
+    <configKey>CA2225</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2225: Operator overloads have named alternates]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An operator overload was detected, and the expected named alternative method was not found.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Operator overloading allows the use of symbols to represent computations for a type. For example, a type that overloads the plus symbol (+) for addition would typically have an alternative member named 'Add'. The named alternative member provides access to the same functionality as the operator, and is provided for developers who program in languages that do not support overloaded operators.
+            This rule examines the operators listed in the following table.
+
+
+
+
+
+
+
+                    C#
+
+
+                    Visual Basic
+
+
+                    C++
+
+
+                    Alternate name
+
+
+
+
+                    + (binary)
+
+
+                    +
+
+
+                    + (binary)
+
+
+                    Add
+
+
+
+
+                    +=
+
+
+                    +=
+
+
+                    +=
+
+
+                    Add
+
+
+
+
+                    &amp;
+
+
+                    And
+
+
+                    &amp;
+
+
+                    BitwiseAnd
+
+
+
+
+                    &amp;=
+
+
+                    And=
+
+
+                    &amp;=
+
+
+                    BitwiseAnd
+
+
+
+
+                    |
+
+
+                    Or
+
+
+                    |
+
+
+                    BitwiseOr
+
+
+
+
+                    |=
+
+
+                    Or=
+
+
+                    |=
+
+
+                    BitwiseOr
+
+
+
+
+                    --
+
+
+                    N/A
+
+
+                    --
+
+
+                    Decrement
+
+
+
+
+                    /
+
+
+                    /
+
+
+                    /
+
+
+                    Divide
+
+
+
+
+                    /=
+
+
+                    /=
+
+
+                    /=
+
+
+                    Divide
+
+
+
+
+                    ==
+
+
+                    =
+
+
+                    ==
+
+
+                    Equals
+
+
+
+
+                    ^
+
+
+                    Xor
+
+
+                    ^
+
+
+                    Xor
+
+
+
+
+                    ^=
+
+
+                    Xor=
+
+
+                    ^=
+
+
+                    Xor
+
+
+
+
+                    &gt;
+
+
+                    &gt;
+
+
+                    &gt;
+
+
+                    Compare
+
+
+
+
+                    &gt;=
+
+
+                    &gt;=
+
+
+                    &gt;=
+
+
+                    Compare
+
+
+
+
+                    ++
+
+
+                    N/A
+
+
+                    ++
+
+
+                    Increment
+
+
+
+
+                    !=
+
+
+                    &lt;&gt;
+
+
+                    !=
+
+
+                    Equals
+
+
+
+
+                    &lt;&lt;
+
+
+                    &lt;&lt;
+
+
+                    &lt;&lt;
+
+
+                    LeftShift
+
+
+
+
+                    &lt;&lt;=
+
+
+                    &lt;&lt;=
+
+
+                    &lt;&lt;=
+
+
+                    LeftShift
+
+
+
+
+                    &lt;
+
+
+                    &lt;
+
+
+                    &lt;
+
+
+                    Compare
+
+
+
+
+                    &lt;=
+
+
+                    &lt;=
+
+
+                    &lt;=
+
+
+                    Compare
+
+
+
+
+                    &amp;&amp;
+
+
+                    N/A
+
+
+                    &amp;&amp;
+
+
+                    LogicalAnd
+
+
+
+
+                    ||
+
+
+                    N/A
+
+
+                    ||
+
+
+                    LogicalOr
+
+
+
+
+                    !
+
+
+                    N/A
+
+
+                    !
+
+
+                    LogicalNot
+
+
+
+
+                    %
+
+
+                    Mod
+
+
+                    %
+
+
+                    Mod or Remainder
+
+
+
+
+                    %=
+
+
+                    N/A
+
+
+                    %=
+
+
+                    Mod
+
+
+
+
+                    * (binary)
+
+
+                    *
+
+
+                    *
+
+
+                    Multiply
+
+
+
+
+                    *=
+
+
+                    N/A
+
+
+                    *=
+
+
+                    Multiply
+
+
+
+
+                    ~
+
+
+                    Not
+
+
+                    ~
+
+
+                    OnesComplement
+
+
+
+
+                    &gt;&gt;
+
+
+                    &gt;&gt;
+
+
+                    &gt;&gt;
+
+
+                    RightShift
+
+
+
+
+                    &gt;&gt;=
+
+
+                    N/A
+
+
+                    &gt;&gt;=
+
+
+                    RightShift
+
+
+
+
+                    - (binary)
+
+
+                    - (binary)
+
+
+                    - (binary)
+
+
+                    Subtract
+
+
+
+
+                    -=
+
+
+                    N/A
+
+
+                    -=
+
+
+                    Subtract
+
+
+
+
+                    true
+
+
+                    IsTrue
+
+
+                    N/A
+
+
+                    IsTrue (Property)
+
+
+
+
+                    - (unary)
+
+
+                    N/A
+
+
+                    -
+
+
+                    Negate
+
+
+
+
+                    + (unary)
+
+
+                    N/A
+
+
+                    +
+
+
+                    Plus
+
+
+
+
+                    false
+
+
+                    IsFalse
+
+
+                    False
+
+
+                    IsTrue (Property)
+
+
+
+
+            N/A == Cannot be overloaded in the selected language.
+            The rule also checks implicit and explicit cast operators in a type (SomeType) by checking for methods named ToSomeType and FromSomeType.
+            In C#, when a binary operator is overloaded, the corresponding assignment operator, if any, is also implicitly overloaded.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, implement the alternative method for the operator; name it using the recommended alternative name.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule if you are implementing a shared library. Applications can ignore a warning from this rule.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:DoNotOverloadOperatorEqualsOnReferenceTypes}<br/>
+
+
+
+
+                {rule:fxcop:OperatorsShouldHaveSymmetricalOverloads}<br/>
+
+
+
+
+                {rule:fxcop:OverrideEqualsOnOverloadingOperatorEquals}<br/>
+
+
+
+
+                {rule:fxcop:OverrideGetHashCodeOnOverridingEquals}<br/>
+
+
+
+
+                {rule:fxcop:OverloadOperatorEqualsOnOverridingValueTypeEquals}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182355.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182355.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="OperatorsShouldHaveSymmetricalOverloads">
+    <configKey>CA2226</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2226: Operators should have symmetrical overloads]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type implements the equality or inequality operator and does not implement the opposite operator.
+</p>
+<h2>Rule Description</h2>
+<p>
+            There are no circumstances where either equality or inequality is applicable to instances of a type, and the opposite operator is undefined. Types typically implement the inequality operator by returning the negated value of the equality operator.
+            The C# compiler issues an error for violations of this rule.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, implement both the equality and inequality operators, or remove the one that is present.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule. Your type will not work in a manner that is consistent with the .NET Framework.
+</p>
+<h2>Related Rules</h2>
+<p>
+
+
+                {rule:fxcop:DoNotOverloadOperatorEqualsOnReferenceTypes}<br/>
+
+
+
+
+                {rule:fxcop:OperatorOverloadsHaveNamedAlternates}<br/>
+
+
+
+
+                {rule:fxcop:OverrideEqualsOnOverloadingOperatorEquals}<br/>
+
+
+
+
+                {rule:fxcop:OverrideGetHashCodeOnOverridingEquals}<br/>
+
+
+
+
+                {rule:fxcop:OverloadOperatorEqualsOnOverridingValueTypeEquals}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182356.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182356.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="CollectionPropertiesShouldBeReadOnly">
+    <configKey>CA2227</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2227: Collection properties should be read only]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An externally visible writable property is a type that implements <code>System.Collections.ICollection</code>. Arrays, indexers (properties with the name 'Item'), and permission sets are ignored by the rule.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A writable collection property allows a user to replace the collection with a completely different collection. A read-only property stops the collection from being replaced but still allows the individual members to be set. If replacing the collection is a goal, the preferred design pattern is to include a method to remove all the elements from the collection and a method to re-populate the collection. See the <code>Clear</code> and <code>AddRange</code> methods of the <code>System.Collections.ArrayList</code> class for an example of this pattern.
+            Both binary and XML serialization support read-only properties that are collections. The <code>System.Xml.Serialization.XmlSerializer</code> class has specific requirements for types that implement <code>ICollection</code> and <code>System.Collections.IEnumerable</code> in order to be serializable.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, make the property read-only and, if the design requires it, add methods to clear and re-populate the collection.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                <code>CA1819: Properties should not return arrays</code>
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182327.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182327.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="DoNotShipUnreleasedResourceFormats">
+    <configKey>CA2228</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2228: Do not ship unreleased resource formats]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A resource file was built using a version of the .NET Framework that is not currently supported.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Resource files that were built by using pre-release versions of the .NET Framework might not be usable by supported versions of the .NET Framework.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, build the resource using a supported version of the .NET Frameworkk.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182339.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182339.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ImplementSerializationConstructors">
+    <configKey>CA2229</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2229: Implement serialization constructors]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The type implements the <code>System.Runtime.Serialization.ISerializable</code> interface, is not a delegate or interface, and one of the following conditions is true:
+            <ul>
+              <li>
+                The type does not have a constructor that takes a <code>System.Runtime.Serialization.SerializationInfo</code> object and a <code>System.Runtime.Serialization.StreamingContext</code> object (the signature of the serialization constructor).
+              </li>
+              <li>
+                The type is unsealed and the access modifier for its serialization constructor is not protected (family).
+              </li>
+              <li>
+                The type is sealed and the access modifier for its serialization constructor is not private.
+              </li>
+            </ul>
+</p>
+<h2>Rule Description</h2>
+<p>
+            This rule is relevant for types that support custom serialization. A type supports custom serialization if it implements the <code>ISerializable</code> interface. The serialization constructor is required to deserialize, or re-create objects that have been serialized using the <code>ISerializable.GetObjectData</code> method.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, implement the serialization constructor. For a sealed class, make the constructor private; otherwise, make it protected.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a violation of the rule. The type will not be deserializable, and will not function in many scenarios.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:MarkISerializableTypesWithSerializable}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182343.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182343.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="UseParamsForVariableArguments">
+    <configKey>CA2230</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2230: Use params for variable arguments]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A public or protected type contains a public or protected method that uses the <code>VarArgs</code> calling convention.
+</p>
+<h2>Rule Description</h2>
+<p>
+            The <code>VarArgs</code> calling convention is used with certain method definitions that take a variable number of parameters. A method using the <code>VarArgs</code> calling convention is not Common Language Specification (CLS) compliant and might not be accessible across programming languages.
+            In C#, the <code>VarArgs</code> calling convention is used when a method's parameter list ends with the <code>__arglist</code> keyword. Visual Basic does not support the <code>VarArgs</code> calling convention, and Visual C++  allows its use only in unmanaged code that uses the ellipse <code>...</code> notation.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule in C#, use the params (C# Reference) keyword instead of <code>__arglist</code>.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182366.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182366.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="OverloadOperatorEqualsOnOverridingValueTypeEquals">
+    <configKey>CA2231</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2231: Overload operator equals on overriding ValueType.Equals]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A value type overrides <code>Object.Equals</code> but does not implement the equality operator.
+</p>
+<h2>Rule Description</h2>
+<p>
+            In most programming languages there is no default implementation of the equality operator (==) for value types. If your programming language supports operator overloads, you should consider implementing the equality operator. Its behavior should be identical to that of <code>Equals</code>.
+            You cannot use the default equality operator in an overloaded implementation of the equality operator. Doing so will cause a stack overflow. To implement the equality operator, use the Object.Equals method in your implementation. For example:
+
+
+
+
+
+
+
+
+
+            <pre>
+If (Object.ReferenceEquals(left, Nothing)) Then
+    Return Object.ReferenceEquals(right, Nothing)
+Else
+    Return left.Equals(right)
+End If
+</pre>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+            <pre>
+if (Object.ReferenceEquals(left, null))
+    return Object.ReferenceEquals(right, null);
+return left.Equals(right);
+</pre>
+
+
+
+
+
+
+
+
+
+
+
+                How to Fix Violations
+
+
+
+
+
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule; however, we recommend that you provide the equality operator if possible.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:DoNotOverloadOperatorEqualsOnReferenceTypes}<br/>
+
+
+
+
+                {rule:fxcop:OperatorOverloadsHaveNamedAlternates}<br/>
+
+
+
+
+                {rule:fxcop:OperatorsShouldHaveSymmetricalOverloads}<br/>
+
+
+
+
+                {rule:fxcop:OverrideEqualsOnOverloadingOperatorEquals}<br/>
+
+
+
+
+                {rule:fxcop:OverrideGetHashCodeOnOverridingEquals}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182359.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182359.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="MarkWindowsFormsEntryPointsWithStaThread">
+    <configKey>CA2232</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2232: Mark Windows Forms entry points with STAThread]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An assembly references the <code>System.Windows.Forms</code> namespace, and its entry point is not marked with the <code>System.STAThreadAttribute</code> attribute.
+</p>
+<h2>Rule Description</h2>
+<p>
+
+
+                <code>STAThreadAttribute</code>
+               indicates that the COM threading model for the application is single-threaded apartment. This attribute must be present on the entry point of any application that uses Windows Forms; if it is omitted, the Windows components might not work correctly. If the attribute is not present, the application uses the multithreaded apartment model, which is not supported for Windows Forms.
+
+
+
+
+
+                    Note
+
+
+
+
+                     Visual Basic projects that use the Application Framework do not have to mark the Main method with STAThread. The Visual Basic compiler does it automatically.
+
+
+
+
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, add the <code>STAThreadAttribute</code> attribute to the entry point. If the <code>System.MTAThreadAttribute</code> attribute is present, remove it.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if you are developing for the .NET Compact Framework, for which the <code>STAThreadAttribute</code> attribute is unnecessary and not supported.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182351.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182351.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="OperationsShouldNotOverflow">
+    <configKey>CA2233</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2233: Operations should not overflow]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method performs an arithmetic operation and does not validate the operands beforehand to prevent overflow.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Arithmetic operations should not be performed without first validating the operands to make sure that the result of the operation is not outside the range of possible values for the data types involved. Depending on the execution context and the data types involved, arithmetic overflow can result in either a <code>System.OverflowException</code> or the most significant bits of the result discarded.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, validate the operands before you perform the operation.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if the possible values of the operands will never cause the arithmetic operation to overflow.
+</p>
+<h2>Example of a Violation</h2>
+
+<h3>Description</h3>
+<p>
+                A method in the following example manipulates an integer that violates this rule. Visual Basic requires the Remove integer overflow option to be disabled for this to fire.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+
+namespace Samples
+{
+    public static class Calculator
+    {
+        public static int Decrement(int input)
+        {
+            // Violates this rule
+            input--;
+            return input;
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h3>Comments</h3>
+<p>
+                If the method in this example is passed MinValue, the operation would underflow. This causes the most significant bit of the result to be discarded. The following code shows how this occurs.
+                [C#]
+
+
+
+
+
+
+
+
+
+            <pre>
+public static void Main()
+{
+    int value = int.MinValue;    // int.MinValue is -2147483648
+    value = Calculator.Decrement(value);
+    Console.WriteLine(value);
+}
+</pre>
+
+
+
+
+[VB]
+
+
+
+
+
+
+
+
+
+            <pre>
+Public Shared Sub Main()
+    Dim value = Integer.MinValue    ' Integer.MinValue is -2147483648
+    value = Calculator.Decrement(value)
+    Console.WriteLine(value)
+End Sub
+</pre>
+
+
+
+
+
+
+
+
+
+
+
+                    Output
+
+
+
+
+
+</p>
+<h2>Fix with Input Parameter Validation</h2>
+
+<h3>Description</h3>
+<p>
+                The following example fixes the previous violation by validating the value of input.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+
+namespace Samples
+{
+    public static class Calculator
+    {
+        public static int Decrement(int input)
+        {
+            if (input == int.MinValue)
+                throw new ArgumentOutOfRangeException("input", "input must be greater than Int32.MinValue");
+
+            input--;
+            return input;
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>Fix with a Checked Block</h2>
+
+<h3>Description</h3>
+<p>
+                The following example fixes the previous violation by wrapping the operation in a checked block. If the operation causes an overflow, a <code>System.OverflowException</code> will be thrown.
+                Note that checked blocks are not supported in Visual Basic.
+</p>
+<h3>Code</h3>
+<p>
+
+
+
+
+
+
+
+
+
+
+            <pre>
+using System;
+
+namespace Samples
+{
+    public static class Calculator
+    {
+        public static int Decrement(int input)
+        {
+            checked
+            {
+                input--;
+            }
+
+            return input;
+        }
+    }
+}
+</pre>
+
+
+
+
+
+</p>
+<h2>Turn on Checked Arithmetic Overflow/Underflow</h2>
+<p>
+            If you turn on checked arithmetic overflow/underflow in C#, it is equivalent to wrapping every integer operation in a checked block.
+
+              To turn on checked arithmetic overflow/underflow in C#
+
+
+              <li>
+                In Solution Explorer, right-click your project and choose Properties.
+              </li>
+              <li>
+                Select the Build tab and click Advanced.
+              </li>
+              <li>
+                Select Check for arithmetic overflow/underflow and click OK.
+              </li>
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182354.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182354.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="PassSystemUriObjectsInsteadOfStrings">
+    <configKey>CA2234</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2234: Pass System.Uri objects instead of strings]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A call is made to a method that has a string parameter whose name contains "uri", "Uri", "urn", "Urn", "url", or "Url"; and the declaring type of the method contains a corresponding method overload that has a <code>System.Uri</code> parameter.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A parameter name is split into tokens based on the camel casing convention, and then each token is checked to see whether it equals "uri", "Uri", "urn", "Urn", "url", or "Url". If there is a match, the parameter is assumed to represent a uniform resource identifier (URI). A string representation of a URI is prone to parsing and encoding errors, and can lead to security vulnerabilities. The <code>Uri</code> class provides these services in a safe and secure manner. When there is a choice between two overloads that differ only regarding the representation of a URI, the user should choose the overload that takes a <code>Uri</code> argument.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, call the overload that takes the <code>Uri</code> argument.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if the string parameter does not represent a URI.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:StringUriOverloadsCallSystemUriOverloads}<br/>
+
+
+
+
+                {rule:fxcop:UriPropertiesShouldNotBeStrings}<br/>
+
+
+
+
+                {rule:fxcop:UriParametersShouldNotBeStrings}<br/>
+
+
+
+
+                {rule:fxcop:UriReturnValuesShouldNotBeStrings}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182360.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182360.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="MarkAllNonSerializableFields">
+    <configKey>CA2235</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2235: Mark all non-serializable fields]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An instance field of a type that is not serializable is declared in a type that is serializable.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A serializable type is one that is marked with the <code>System.SerializableAttribute</code> attribute. When the type is serialized, a <code>System.Runtime.Serialization.SerializationException</code> exception is thrown if a type contains an instance field of a type that is not serializable.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, apply the <code>System.NonSerializedAttribute</code> attribute to the field that is not serializable.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Only suppress a warning from this rule if a <code>System.Runtime.Serialization.ISerializationSurrogate</code> type is declared that allows instances of the field to be serialized and deserialized.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:CallBaseClassMethodsOnISerializableTypes}<br/>
+
+
+
+
+                {rule:fxcop:ImplementISerializableCorrectly}<br/>
+
+
+
+
+                {rule:fxcop:ImplementSerializationConstructors}<br/>
+
+
+
+
+                {rule:fxcop:ImplementSerializationMethodsCorrectly}<br/>
+
+
+
+
+                {rule:fxcop:MarkISerializableTypesWithSerializable}<br/>
+
+
+
+
+                {rule:fxcop:ProvideDeserializationMethodsForOptionalFields}<br/>
+
+
+
+
+                {rule:fxcop:SecureSerializationConstructors}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182349.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182349.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="CallBaseClassMethodsOnISerializableTypes">
+    <configKey>CA2236</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2236: Call base class methods on ISerializable types]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type derives from a type that implements the <code>System.Runtime.Serialization.ISerializable</code> interface, and one of the following conditions is true:
+            <ul>
+              <li>
+                The type implements the serialization constructor, that is, a constructor with the <code>System.Runtime.Serialization.SerializationInfo</code>, <code>System.Runtime.Serialization.StreamingContext</code> parameter signature, but does not call the serialization constructor of the base type.
+              </li>
+              <li>
+                The type implements the <code>ISerializable.GetObjectData</code> method but does not call the <code>GetObjectData</code> method of the base type.
+              </li>
+            </ul>
+</p>
+<h2>Rule Description</h2>
+<p>
+            In a custom serialization process, a type implements the <code>GetObjectData</code> method to serialize its fields and the serialization constructor to de-serialize the fields. If the type derives from a type that implements the <code>ISerializable</code> interface, the base type <code>GetObjectData</code> method and serialization constructor should be called to serialize/de-serialize the fields of the base type. Otherwise, the type will not be serialized and de-serialized correctly. Note that if the derived type does not add any new fields, the type does not need to implement the <code>GetObjectData</code> method nor the serialization constructor or call the base type equivalents.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, call the base type <code>GetObjectData</code> method or serialization constructor from the corresponding derived type method or constructor.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:ImplementISerializableCorrectly}<br/>
+
+
+
+
+                {rule:fxcop:ImplementSerializationConstructors}<br/>
+
+
+
+
+                {rule:fxcop:ImplementSerializationMethodsCorrectly}<br/>
+
+
+
+
+                {rule:fxcop:MarkAllNonSerializableFields}<br/>
+
+
+
+
+                {rule:fxcop:MarkISerializableTypesWithSerializable}<br/>
+
+
+
+
+                {rule:fxcop:ProvideDeserializationMethodsForOptionalFields}<br/>
+
+
+
+
+                {rule:fxcop:SecureSerializationConstructors}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182326.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182326.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="MarkISerializableTypesWithSerializable">
+    <configKey>CA2237</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2237: Mark ISerializable types with SerializableAttribute]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An externally visible type implements the <code>System.Runtime.Serialization.ISerializable</code> interface and the type is not marked with the <code>System.SerializableAttribute</code> attribute. The rule ignores derived types whose base type is not serializable.
+</p>
+<h2>Rule Description</h2>
+<p>
+            To be recognized by the common language runtime as serializable, types must be marked with the <code>SerializableAttribute</code> attribute even if the type uses a custom serialization routine through implementation of the <code>ISerializable</code> interface.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, apply the <code>SerializableAttribute</code> attribute to the type.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule for exception classes because they must be serializable to work correctly across application domains.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:CallBaseClassMethodsOnISerializableTypes}<br/>
+
+
+
+
+                {rule:fxcop:ImplementISerializableCorrectly}<br/>
+
+
+
+
+                {rule:fxcop:ImplementSerializationConstructors}<br/>
+
+
+
+
+                {rule:fxcop:ImplementSerializationMethodsCorrectly}<br/>
+
+
+
+
+                {rule:fxcop:MarkAllNonSerializableFields}<br/>
+
+
+
+
+                {rule:fxcop:ProvideDeserializationMethodsForOptionalFields}<br/>
+
+
+
+
+                {rule:fxcop:SecureSerializationConstructors}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182350.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182350.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ImplementSerializationMethodsCorrectly">
+    <configKey>CA2238</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2238: Implement serialization methods correctly]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A method that handles a serialization event does not have the correct signature, return type, or visibility.
+</p>
+<h2>Rule Description</h2>
+<p>
+            A method is designated a serialization event handler by applying one of the following serialization event attributes:
+            <ul>
+              <li>
+
+
+                    <code>System.Runtime.Serialization.OnSerializingAttribute</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.Runtime.Serialization.OnSerializedAttribute</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.Runtime.Serialization.OnDeserializingAttribute</code>
+
+
+              </li>
+              <li>
+
+
+                    <code>System.Runtime.Serialization.OnDeserializedAttribute</code>
+
+
+              </li>
+            </ul>
+            Serialization event handlers take a single parameter of type <code>System.Runtime.Serialization.StreamingContext</code>, return <code>void</code>, and have <code>private</code> visibility.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, correct the signature, return type, or visibility of the serialization event handler.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:CallBaseClassMethodsOnISerializableTypes}<br/>
+
+
+
+
+                {rule:fxcop:ImplementISerializableCorrectly}<br/>
+
+
+
+
+                {rule:fxcop:ImplementSerializationConstructors}<br/>
+
+
+
+
+                {rule:fxcop:MarkAllNonSerializableFields}<br/>
+
+
+
+
+                {rule:fxcop:MarkISerializableTypesWithSerializable}<br/>
+
+
+
+
+                {rule:fxcop:ProvideDeserializationMethodsForOptionalFields}<br/>
+
+
+
+
+                {rule:fxcop:SecureSerializationConstructors}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182344.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182344.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ProvideDeserializationMethodsForOptionalFields">
+    <configKey>CA2239</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2239: Provide deserialization methods for optional fields]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A type has a field that is marked with the <code>System.Runtime.Serialization.OptionalFieldAttribute</code> attribute and the type does not provide de-serialization event handling methods.
+</p>
+<h2>Rule Description</h2>
+<p>
+            The <code>OptionalFieldAttribute</code> attribute has no effect on serialization; a field marked with the attribute is serialized. However, the field is ignored on de-serialization and retains the default value associated with its type. De-serialization event handlers should be declared to set the field during the de-serialization process.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, add de-serialization event handling methods to the type.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if the field should be ignored during the de-serialization process.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:CallBaseClassMethodsOnISerializableTypes}<br/>
+
+
+
+
+                {rule:fxcop:ImplementISerializableCorrectly}<br/>
+
+
+
+
+                {rule:fxcop:ImplementSerializationConstructors}<br/>
+
+
+
+
+                {rule:fxcop:ImplementSerializationMethodsCorrectly}<br/>
+
+
+
+
+                {rule:fxcop:MarkAllNonSerializableFields}<br/>
+
+
+
+
+                {rule:fxcop:MarkISerializableTypesWithSerializable}<br/>
+
+
+
+
+                {rule:fxcop:SecureSerializationConstructors}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182362.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182362.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ImplementISerializableCorrectly">
+    <configKey>CA2240</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2240: Implement ISerializable correctly]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An externally visible type is assignable to the <code>System.Runtime.Serialization.ISerializable</code> interface and one of the following conditions is true:
+            <ul>
+              <li>
+                The type inherits but does not override the <code>ISerializable.GetObjectData</code> method and the type declares instance fields that are not marked with the <code>System.NonSerializedAttribute</code> attribute.
+              </li>
+              <li>
+                The type is not sealed and the type implements a <code>GetObjectData</code> method that is not externally visible and overridable.
+              </li>
+            </ul>
+</p>
+<h2>Rule Description</h2>
+<p>
+            Instance fields that are declared in a type that inherits the <code>System.Runtime.Serialization.ISerializable</code> interface are not automatically included in the serialization process. To include the fields, the type must implement the <code>GetObjectData</code> method and the serialization constructor. If the fields should not be serialized, apply the <code>NonSerializedAttribute</code> attribute to the fields to explicitly indicate the decision.
+            In types that are not sealed, implementations of the <code>GetObjectData</code> method should be externally visible. Therefore, the method can be called by derived types, and is overridable.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, make the <code>GetObjectData</code> method visible and overridable and make sure all instance fields are included in the serialization process or explicitly marked with the <code>NonSerializedAttribute</code> attribute.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p>
+<h2>Example</h2>
+<p>
+
+
+                {rule:fxcop:CallBaseClassMethodsOnISerializableTypes}<br/>
+
+
+
+
+                {rule:fxcop:ImplementSerializationConstructors}<br/>
+
+
+
+
+                {rule:fxcop:ImplementSerializationMethodsCorrectly}<br/>
+
+
+
+
+                {rule:fxcop:MarkAllNonSerializableFields}<br/>
+
+
+
+
+                {rule:fxcop:MarkISerializableTypesWithSerializable}<br/>
+
+
+
+
+                {rule:fxcop:ProvideDeserializationMethodsForOptionalFields}<br/>
+
+
+
+
+                {rule:fxcop:SecureSerializationConstructors}
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182342.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182342.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="ProvideCorrectArgumentsToFormattingMethods">
+    <configKey>CA2241</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2241: Provide correct arguments to formatting methods]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            The format string argument passed to a method such as <code>WriteLine</code>,  <code>Write</code>, or  <code>String.Format</code> does not contain a format item that corresponds to each object argument, or vice versa.
+</p>
+<h2>Rule Description</h2>
+<p>
+            The arguments to methods such as <code>WriteLine</code>, <code>Write</code>, and <code>Format</code> consist of a format string followed by several <code>System.Object</code> instances. The format string consists of text and embedded format items of the form, {index[,alignment][:formatString]}. 'index' is a zero-based integer that indicates which of the objects to format. If an object does not have a corresponding index in the format string, the object is ignored. If the object specified by 'index' does not exist, a <code>System.FormatException</code> is thrown at runtime.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule, provide a format item for each object argument and provide an object argument for each format item.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/ms182361.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/ms182361.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="TestForNaNCorrectly">
+    <configKey>CA2242</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2242: Test for NaN correctly]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An expression tests a value against <code>Single.Nan</code> or <code>Double.Nan</code>.
+</p>
+<h2>Rule Description</h2>
+<p>
+
+
+                <code>Double.NaN</code>
+              , which represents not-a-number, results when an arithmetic operation is undefined. Any expression that tests equality between a value and <code>Double.NaN</code> always returns <code>false</code>. Any expression that tests inequality between a value and <code>Double.NaN</code> always returns <code>true</code>.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To fix a violation of this rule and accurately determine whether a value represents <code>Double.NaN</code>, use <code>Single.IsNan</code> or <code>Double.IsNan</code> to test the value.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            Do not suppress a warning from this rule.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb264491.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb264491.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="AttributeStringLiteralsShouldParseCorrectly">
+    <configKey>CA2243</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA2243: Attribute string literals should parse correctly]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            An attribute's string literal parameter does not parse correctly for a URL, GUID, or Version.
+</p>
+<h2>Rule Description</h2>
+<p>
+            Since attributes are derived from <code>System.Attribute</code>, and attributes are used at compile time, only constant values can be passed to their constructors. Attribute parameters that must represent URLs, GUIDs and Versions cannot be typed as <code>System.Uri</code>, <code>System.Guid</code>, and <code>System.Version</code>, because these types cannot be represented as constants. Instead, they must be represented by strings.
+            Because the parameter is typed as a string, it is possible that an incorrectly formatted parameter could be passed at compile time.
+            This rule uses a naming heuristic to find parameters that represent a uniform resource identifier (URI), a Globally Unique Identifier (GUID) or a Version and verifies that the passed value is correct.
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            Change the parameter string to a correctly formed URL, GUID, or Version.
+</p>
+<h2>When to Suppress Warnings</h2>
+<p>
+            It is safe to suppress a warning from this rule if the parameter does not represent a URL, GUID, or Version.
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/bb264490.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/bb264490.aspx</a></p>
+]]></description>
+  </rule>
+
+
+  <rule key="PInvokesShouldNotBeSafeCriticalFxCopRule">
+    <configKey>CA5122</configKey>
+    <priority>MAJOR</priority>
+    <name><![CDATA[CA5122: P/Invoke declarations should not be safe critical]]></name>
+    <description><![CDATA[
+<h2>Cause</h2>
+<p>
+            A P/Invoke declaration has been marked with a <code>SecuritySafeCriticalAttribute</code>:
+
+
+
+
+
+
+
+
+
+            <pre>
+[assembly: AllowPartiallyTrustedCallers]
+
+// ...
+public class C
+{
+    [SecuritySafeCritical]
+    [DllImport("kernel32.dll")]
+    public static extern bool Beep(int frequency, int duration); // CA5122 – safe critical p/invoke
+   }
+</pre>
+
+
+
+
+In this example, C.Beep(...) has been marked as a security safe critical method.
+
+
+
+
+
+
+                Rule Description
+
+
+
+
+
+</p>
+<h2>How to Fix Violations</h2>
+<p>
+            To make a P/Invoke available to transparent code, expose a security safe critical wrapper method for it:
+
+
+
+
+
+
+
+
+
+            <pre>
+[assembly: AllowPartiallyTrustedCallers
+
+class C
+{
+   [SecurityCritical]
+   [DllImport(“kernel32.dll”, EntryPoint=”Beep”)]
+   private static extern bool BeepPinvoke(int frequency, int duration); // Security Critical P/Invoke
+
+   [SecuritySafeCritical]
+   public static bool Beep(int frequency, int duration)
+   {
+      return BeepPInvoke(frequency, duration);
+   }
+}
+</pre>
+
+
+
+
+
+
+
+
+
+
+
+                When to Suppress Warnings
+
+
+
+
+
+</p><h2>MSDN Documentation</h2>
+<p><a href="http://msdn.microsoft.com/en-us/library/dn621099.aspx" target="_blank">http://msdn.microsoft.com/en-us/library/dn621099.aspx</a></p>
+]]></description>
+  </rule>
+
+</rules>


### PR DESCRIPTION
fxcop is general tool that inspects managed code, there is no reason not to allow the library to be reused by any managed language. in this case fsharp


i think a more proper solution would be remove the language and the rules xmls from there since the rules are fxcop specific not language specific. 
